### PR TITLE
feat: populate jargon terms

### DIFF
--- a/jargon.yaml
+++ b/jargon.yaml
@@ -196,6 +196,10 @@ terms:
     categories:
       - language
       - Armenia
+  ARP:
+    expanded_form: Address Resolution Protocol
+    categories:
+      - network
   Asana:
     categories:
       - software
@@ -224,6 +228,10 @@ terms:
   Atlassian:
     categories:
       - company
+  ATM:
+    expanded_form: Asynchronous Transfer Mode
+    categories:
+      - network
   Audi:
     categories:
       - automotive
@@ -311,6 +319,17 @@ terms:
   Berkeley DB:
     categories:
       - database
+  BGP:
+    expanded_form: Border Gateway Protocol
+    categories:
+      - network
+  Big Five:
+    categories:
+      - Alphabet Inc.
+      - Meta Platforms, Inc.
+      - Microsoft
+      - Apple
+      - Amazon
   BigQuery:
     categories:
       - database
@@ -1354,6 +1373,10 @@ terms:
     expanded_form: Google Remote Procedure Call
     categories:
       - api
+  GSM:
+    expanded_form: Global System for Mobile Communications
+    categories:
+      - network
   GUI:
     expanded_form: Graphical User Interface
     categories:
@@ -1664,6 +1687,10 @@ terms:
     expanded_form: International Standard Book Number
     categories:
       - standard
+  ISDN:
+    expanded_form: Integrated Services Digital Network
+    categories:
+      - network
   ISO:
     expanded_form: International Organization for Standardization
     categories:
@@ -2157,6 +2184,10 @@ terms:
     expanded_form: Mozilla Public License 2.0
     categories:
       - license
+  MPLS:
+    expanded_form: Multiprotocol Label Switching
+    categories:
+      - network
   MQTT:
     expanded_form: Message Queuing Telemetry Transport
     categories:
@@ -2190,6 +2221,10 @@ terms:
     categories:
       - organization
       - aerospace
+  NAT:
+    expanded_form: Network Address Translation
+    categories:
+      - network
   NATO:
     expanded_form: North Atlantic Treaty Organization
     categories:
@@ -2665,6 +2700,10 @@ terms:
     categories:
       - software
       - Microsoft Windows
+  PPP:
+    expanded_form: Point-to-Point Protocol
+    categories:
+      - network
   Prettier:
     disambiguation:
       - prettier (the adjective)
@@ -2738,6 +2777,10 @@ terms:
     expanded_form: Role-Based Access Control
     categories:
       - authentication
+  RDP:
+    expanded_form: Remote Desktop Protocol
+    categories:
+      - network
   RDS:
     expanded_form: Amazon Relational Database Service
     categories:
@@ -3034,6 +3077,11 @@ terms:
     categories:
       - networking
       - email
+  SNMP:
+    expanded_form: Simple Network Management Protocol
+    categories:
+      - network
+      - monitoring
   SOAP:
     expanded_form: Simple Object Access Protocol
     categories:
@@ -3644,6 +3692,10 @@ terms:
     expanded_form: Windows, Apache, MySQL, PHP
     categories:
       - software stack
+  WAN:
+    expanded_form: Wide Area Network
+    categories:
+      - network
   Wasm:
     expanded_form: WebAssembly
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -39,6 +39,10 @@ terms:
     categories:
       - hardware
       - audio
+  AIX:
+    expanded_form: Advanced Interactive eXecutive
+    categories:
+      - operating system
   AJAX:
     expanded_form: Asynchronous JavaScript and XML
     categories:
@@ -139,6 +143,9 @@ terms:
     categories:
       - shell
       - programming language
+  BeOS:
+    categories:
+      - operating system
   Bitbucket:
     categories:
       - software
@@ -155,6 +162,10 @@ terms:
     expanded_form: Bayerische Motoren Werke
     categories:
       - automotive
+  Bodhi Linux:
+    categories:
+      - operating system
+      - Linux distribution
   Browserify:
     categories:
       - build tool
@@ -447,6 +458,9 @@ terms:
     expanded_form: Document Object Model
     categories:
       - web development
+  DOS:
+    categories:
+      - operating system
   DSA:
     expanded_form: Digital Signature Algorithm
     categories:
@@ -621,6 +635,9 @@ terms:
   freeCodeCamp:
     categories:
       - education
+  FreeDOS:
+    categories:
+      - operating system
   French:
     categories:
       - language
@@ -774,6 +791,9 @@ terms:
   Hadoop:
     categories:
       - data processing
+  Haiku:
+    categories:
+      - operating system
   HAProxy:
     expanded_form: High Availability Proxy
     categories:
@@ -818,6 +838,10 @@ terms:
   Homebrew:
     categories:
       - package management
+  HP-UX:
+    expanded_form: Hewlett Packard Unix
+    categories:
+      - operating system
   HSL:
     expanded_form: Hue, Saturation, Lightness
     categories:
@@ -961,6 +985,9 @@ terms:
     expanded_form: Internet Protocol version 6
     categories:
       - network
+  IRIX:
+    categories:
+      - operating system
   ISBN:
     expanded_form: International Standard Book Number
     categories:
@@ -1125,6 +1152,10 @@ terms:
   Linux:
     categories:
       - operating system
+  Linux Mint:
+    categories:
+      - operating system
+      - Linux distribution
   LLM:
     expanded_form: Large Language Model
     plural: LLMs
@@ -1147,6 +1178,11 @@ terms:
   Lua:
     categories:
       - programming language
+  Lubuntu:
+    categories:
+      - operating system
+      - Linux distribution
+      - Ubuntu variant
   MacBook:
     categories:
       - hardware
@@ -1180,6 +1216,12 @@ terms:
   Microsoft:
     categories:
       - company
+  Microsoft Windows:
+    categories:
+      - operating system
+  MINIX:
+    categories:
+      - operating system
   MirBSD:
     categories:
       - operating system
@@ -1651,6 +1693,9 @@ terms:
     expanded_form: Python YAML
     categories:
       - data serialization
+  QNX:
+    categories:
+      - operating system
   QoS:
     expanded_form: Quality of Service
     categories:
@@ -1676,6 +1721,9 @@ terms:
     categories:
       - web framework
       - JavaScript
+  ReactOS:
+    categories:
+      - operating system
   Red Hat:
     categories:
       - company
@@ -2092,6 +2140,12 @@ terms:
     categories:
       - operating system
       - Linux distribution
+  Ubuntu MATE:
+    categories:
+      - operating system
+      - Linux distribution
+      - desktop Environment
+      - Ubuntu flavor
   UbuntuCE:
     categories:
       - operating system
@@ -2164,6 +2218,10 @@ terms:
     plural: UUIDs
     categories:
       - identifier
+  UWP:
+    expanded_form: Universal Windows Platform
+    categories:
+      - operating system
   UX:
     expanded_form: User Experience
     categories:
@@ -2387,6 +2445,11 @@ terms:
   XtraBackup:
     categories:
       - backup
+  Xubuntu:
+    categories:
+      - operating system
+      - Linux distribution
+      - Ubuntu variant
   YAML:
     expanded_form: YAML Ain't Markup Language
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -122,6 +122,9 @@ terms:
   AsciiDoc:
     categories:
       - markup language
+  Assembly:
+    categories:
+      - programming language
   AST:
     expanded_form: Abstract Syntax Tree
     categories:
@@ -192,6 +195,12 @@ terms:
     categories:
       - file system
   C:
+    categories:
+      - programming language
+  C#:
+    categories:
+      - programming language
+  C++:
     categories:
       - programming language
   CalDAV:
@@ -319,6 +328,11 @@ terms:
     expanded_form: Create, Read, Update, Delete
     categories:
       - software development
+  Crystal:
+    disambiguation:
+      - crystal (the mineral)
+    categories:
+      - programming language
   CSON:
     expanded_form: CoffeeScript Object Notation
     categories:
@@ -355,6 +369,9 @@ terms:
   Cypress:
     categories:
       - testing
+  D:
+    categories:
+      - programming language
   DAB+:
     expanded_form: Digital Audio Broadcasting Plus
     categories:
@@ -365,6 +382,11 @@ terms:
   Dailymotion:
     categories:
       - video
+  Dart:
+    disambiguation:
+      - dart (the game)
+    categories:
+      - programming language
   DBA:
     expanded_form: Database Administrator
     plural: DBAs
@@ -569,6 +591,9 @@ terms:
   Ext4:
     categories:
       - file system
+  F#:
+    categories:
+      - programming language
   Facebook:
     categories:
       - social media
@@ -718,6 +743,9 @@ terms:
   GnuPG:
     categories:
       - cryptography
+  Go:
+    categories:
+      - programming language
   GoLand:
     categories:
       - ide
@@ -1136,6 +1164,21 @@ terms:
     expanded_form: Lightweight Directory Access Protocol
     categories:
       - directory service
+  Leet:
+    expanded_form: Leet Speak (or 1337)
+    disambiguation:
+      - Leet (the slang term)
+      - Leet (the programming language)
+    categories:
+      - programming language
+      - obfuscation
+  Leet Code:
+    categories:
+      - programming language
+  Leet Speak:
+    categories:
+      - programming language
+      - obfuscation
   LGPL:
     expanded_form: Lesser General Public License
     categories:
@@ -1416,6 +1459,10 @@ terms:
       - database
   OOM:
     expanded_form: Out Of Memory
+    categories:
+      - programming
+  OOP:
+    expanded_form: Object-Oriented Programming
     categories:
       - programming
   OpenAI:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -157,6 +157,10 @@ terms:
   Apache OpenNLP:
     categories:
       - natural language processing
+  APFS:
+    expanded_form: Apple File System
+    categories:
+      - file system
   API:
     expanded_form: Application Programming Interface
     plural: APIs
@@ -999,15 +1003,28 @@ terms:
     expanded_form: Extended File Allocation Table
     categories:
       - file system
+  ext2:
+    categories:
+      - file system
   Ext3:
+    categories:
+      - file system
+  ext3:
     categories:
       - file system
   Ext4:
     categories:
       - file system
+  ext4:
+    categories:
+      - file system
   F#:
     categories:
       - programming language
+  F2FS:
+    expanded_form: Flash-Friendly File System
+    categories:
+      - file system
   FaaS:
     expanded_form: Function as a Service
     categories:
@@ -1024,6 +1041,14 @@ terms:
   Fastly:
     categories:
       - cloud
+  FAT:
+    expanded_form: File Allocation Table
+    categories:
+      - file system
+  FAT16:
+    expanded_form: File Allocation Table 16
+    categories:
+      - file system
   FAT32:
     expanded_form: File Allocation Table 32
     categories:
@@ -1384,6 +1409,14 @@ terms:
   Heroku:
     categories:
       - cloud
+  HFS:
+    expanded_form: Hierarchical File System
+    categories:
+      - file system
+  HFS+:
+    expanded_form: Hierarchical File System Plus
+    categories:
+      - file system
   Hindi:
     categories:
       - language
@@ -1689,17 +1722,32 @@ terms:
   Jenkins:
     categories:
       - continuous integration
+  Jenkinsfile:
+    categories:
+      - configuration file
+      - Jenkins
   JetBrains:
     categories:
       - company
   JetStream:
     categories:
       - messaging
+  JFS:
+    expanded_form: Journaled File System
+    categories:
+      - file system
   Jira:
     categories:
       - software
       - project management
       - bug tracking
+      - Atlassian
+  JPEG:
+    expanded_form: Joint Photographic Experts Group
+    categories:
+      - image format
+      - compression
+      - file extension
   jQuery:
     categories:
       - web framework
@@ -2207,6 +2255,10 @@ terms:
     expanded_form: Not Invented Here
     categories:
       - software development
+  NILFS:
+    expanded_form: New Implementation of a Log-structured File System
+    categories:
+      - file system
   Nissan:
     categories:
       - automotive
@@ -2714,6 +2766,10 @@ terms:
     categories:
       - state management
   RefluxJS:
+  ReFS:
+    expanded_form: Resilient File System
+    categories:
+      - file system
   ReiserFS:
     expanded_form: Reiser File System
     categories:
@@ -3352,6 +3408,10 @@ terms:
     expanded_form: Unified Extensible Firmware Interface
     categories:
       - firmware
+  UFS:
+    expanded_form: Unix File System
+    categories:
+      - file system
   UI:
     expanded_form: User Interface
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -10,6 +10,10 @@ terms:
     expanded_form: Triple Data Encryption Standard
     categories:
       - cryptography
+  ABAC:
+    expanded_form: Attribute-Based Access Control
+    categories:
+      - authentication
   ACID:
     expanded_form: Atomicity, Consistency, Isolation, Durability
     disambiguation:
@@ -217,6 +221,9 @@ terms:
   Australia:
     categories:
       - country
+  Auth0:
+    categories:
+      - authentication
   AutoCAD:
     categories:
       - software
@@ -412,6 +419,11 @@ terms:
       - demonym
       - language
       - Canada
+  CAPTCHA:
+    expanded_form: Completely Automated Public Turing test to tell Computers and Humans Apart
+    plural: CAPTCHAs
+    categories:
+      - authentication
   Caspio:
     categories:
       - database
@@ -700,6 +712,15 @@ terms:
     plural: DDLs
     categories:
       - database
+  DDoS:
+    expanded_form: Distributed Denial of Service
+    categories:
+      - security
+  DEA:
+    expanded_form: Drug Enforcement Administration
+    categories:
+      - government agency
+      - USA
   Debian:
     categories:
       - operating system
@@ -792,6 +813,10 @@ terms:
   DOS:
     categories:
       - operating system
+  DoS:
+    expanded_form: Denial of Service
+    categories:
+      - security
   DRY:
     expanded_form: Don't Repeat Yourself
     disambiguation:
@@ -2224,6 +2249,10 @@ terms:
     expanded_form: Zero Kill (originally a military term)
     categories:
       - general
+  Okta:
+    categories:
+      - authentication
+      - identity
   OLAP:
     expanded_form: Online Analytical Processing
     categories:
@@ -2271,6 +2300,10 @@ terms:
       - graphics
   OpenID:
     expanded_form: Open Identity
+    categories:
+      - authentication
+  OpenID Connect:
+    expanded_form: OpenID Connect
     categories:
       - authentication
   OpenJDK:
@@ -2601,6 +2634,10 @@ terms:
     expanded_form: Random Access Memory
     categories:
       - hardware
+  RBAC:
+    expanded_form: Role-Based Access Control
+    categories:
+      - authentication
   RDS:
     expanded_form: Amazon Relational Database Service
     categories:
@@ -3680,6 +3717,10 @@ terms:
   YouTube:
     categories:
       - video
+  YubiKey:
+    categories:
+      - security
+      - hardware
   ZFS:
     expanded_form: Zettabyte File System
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -14,6 +14,12 @@ terms:
     expanded_form: Attribute-Based Access Control
     categories:
       - authentication
+  ABC:
+    expanded_form: American Broadcasting Company
+    disambiguation:
+      - ABC (the alphabet)
+    categories:
+      - media
   ACID:
     expanded_form: Atomicity, Consistency, Isolation, Durability
     disambiguation:
@@ -294,6 +300,10 @@ terms:
     categories:
       - shell
       - programming language
+  BBC:
+    expanded_form: British Broadcasting Corporation
+    categories:
+      - media
   BCP:
     expanded_form: Business Continuity Planning
     categories:
@@ -495,6 +505,10 @@ terms:
       - language
       - Spain
       - France
+  CBS:
+    expanded_form: Columbia Broadcasting System
+    categories:
+      - media
   CD-ROM:
     expanded_form: Compact Disc Read-Only Memory
     categories:
@@ -996,6 +1010,10 @@ terms:
     categories:
       - linting
       - JavaScript
+  ESPN:
+    categories:
+      - media
+      - sports
   ESSID:
     expanded_form: Extended Service Set Identifier
     categories:
@@ -1162,6 +1180,11 @@ terms:
     expanded_form: Free and Open Source Software
     categories:
       - software
+  Fox:
+    categories:
+      - media
+    disambiguation:
+      - fox (the animal)
   FQCN:
     expanded_form: Fully Qualified Class Name
     categories:
@@ -1426,6 +1449,10 @@ terms:
   HBase:
     categories:
       - database
+  HBO:
+    expanded_form: Home Box Office
+    categories:
+      - media
   HD DVD:
     categories:
       - hardware
@@ -2266,6 +2293,10 @@ terms:
     expanded_form: National Basketball Association
     categories:
       - sports
+  NBC:
+    expanded_form: National Broadcasting Company
+    categories:
+      - media
   NDJSON:
     expanded_form: Newline Delimited JSON
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -294,10 +294,22 @@ terms:
     categories:
       - shell
       - programming language
+  BCP:
+    expanded_form: Business Continuity Planning
+    categories:
+      - business
+      - document
+      - emergency management
   BDD:
     expanded_form: Behavior-Driven Development
     categories:
       - software development
+  BEAP:
+    expanded_form: Business Emergency Action Plan
+    categories:
+      - business
+      - document
+      - emergency management
   Belarus:
     categories:
       - country
@@ -865,6 +877,12 @@ terms:
     expanded_form: Denial of Service
     categories:
       - security
+  DRP:
+    expanded_form: Disaster Recovery Planning
+    categories:
+      - business
+      - document
+      - emergency management
   DRY:
     expanded_form: Don't Repeat Yourself
     disambiguation:
@@ -1712,6 +1730,12 @@ terms:
     categories:
       - country
       - Europe
+  ITCP:
+    expanded_form: Information Technology Contingency Planning
+    categories:
+      - business
+      - document
+      - emergency management
   iTunes:
     categories:
       - software
@@ -2834,6 +2858,16 @@ terms:
   RFC:
     expanded_form: Request for Comments
     categories:
+      - document
+  RFI:
+    expanded_form: Request for Information
+    categories:
+      - business
+      - document
+  RFP:
+    expanded_form: Request for Proposal
+    categories:
+      - business
       - document
   RGB:
     expanded_form: Red Green Blue

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -35,6 +35,11 @@ terms:
   ActionScript:
     categories:
       - programming language
+  Active Directory:
+    categories:
+      - directory service
+      - Microsoft
+      - Windows
   ActiveMQ:
     categories:
       - messaging
@@ -101,9 +106,24 @@ terms:
   Algeria:
     categories:
       - country
+      - Africa
+      - North Africa
+  Algerian:
+    plural: Algerians
+    categories:
+      - nationality
+      - demonym
+      - Algeria
   Algolia:
     categories:
       - search
+  Alphabet:
+    expanded_form: Alphabet Inc.
+    categories:
+      - company
+      - GAFAM
+      - Big Five
+      - Google
   Alpine:
     categories:
       - operating system
@@ -226,9 +246,16 @@ terms:
   AppKit:
     categories:
       - framework
+  Apple:
+    disambiguation:
+      - apple (the fruit)
+    categories:
+      - company
+      - GAFAM
   AppleScript:
     categories:
       - scripting language
+      - Apple
   AppVeyor:
     categories:
       - continuous integration
@@ -353,6 +380,13 @@ terms:
   BadgerDB:
     categories:
       - database
+  Baltic States:
+    categories:
+      - region
+      - Europe
+      - Lithuania
+      - Estonia
+      - Latvia
   Bangladesh:
     categories:
       - country
@@ -687,6 +721,11 @@ terms:
     expanded_form: Continuous Integration
     categories:
       - software development
+  CIA:
+    expanded_form: Central Intelligence Agency
+    categories:
+      - government agency
+      - USA
   CIDR:
     expanded_form: Classless Inter-Domain Routing
     categories:
@@ -753,6 +792,12 @@ terms:
     categories:
       - region
       - organization
+      - treaty
+      - Great Britain
+      - Australia
+      - New Zealand
+      - Pakistan
+      - India
   CommonJS:
     categories:
       - module system
@@ -1185,6 +1230,9 @@ terms:
     expanded_form: Europe, Middle East and Africa
     categories:
       - region
+      - Europe
+      - Middle East
+      - Africa
   English:
     categories:
       - language
@@ -1235,6 +1283,7 @@ terms:
     categories:
       - country
       - Europe
+      - Baltic States
   Estonian:
     plural: Estonians
     categories:
@@ -1315,6 +1364,8 @@ terms:
   Facebook:
     categories:
       - social media
+      - GAFAM
+      - Meta Platforms, Inc.
   FastAPI:
     categories:
       - web framework
@@ -1642,14 +1693,19 @@ terms:
     categories:
       - cryptography
   Go:
+    disambiguation:
+      - Go (the game)
+      - go (the verb)
     categories:
       - programming language
   GoLand:
     categories:
-      - ide
+      - IDE
+      - Go
   Golang:
     categories:
       - programming language
+      - Go
   Google:
     categories:
       - company
@@ -1697,6 +1753,7 @@ terms:
   GopherCon:
     categories:
       - conference
+      - Go
   GPG:
     expanded_form: GNU Privacy Guard
     categories:
@@ -1736,6 +1793,8 @@ terms:
   Great Britain:
     categories:
       - region
+      - United Kingdom
+      - Europe
   Greece:
     categories:
       - country
@@ -1883,6 +1942,14 @@ terms:
     expanded_form: HyperText Transfer Protocol Secure
     categories:
       - protocol
+  Hugo:
+    disambiguation:
+      - Hugo (the author)
+      - Hugo (the character in "Hugo")
+      - Hugo (the firstname)
+    categories:
+      - static site generator
+      - web development
   Hummer:
     categories:
       - automotive
@@ -1900,8 +1967,11 @@ terms:
     categories:
       - software
   Hyundai:
+    expanded_form: Hyundai Motor Company
     categories:
       - automotive
+      - South Korea
+      - company
   Hz:
     expanded_form: Hertz
     categories:
@@ -1926,6 +1996,18 @@ terms:
     expanded_form: Internet Assigned Numbers Authority
     categories:
       - organization
+      - internet
+      - ICANN
+  ARIN:
+    expanded_form: American Registry for Internet Numbers
+    categories:
+      - organization
+      - internet
+      - USA
+  ARPANET:
+    expanded_form: Advanced Research Projects Agency Network
+    categories:
+      - network
   IBM:
     expanded_form: International Business Machines
     categories:
@@ -2040,6 +2122,8 @@ terms:
   Instagram:
     categories:
       - social media
+      - photo sharing
+      - Meta Platforms, Inc.
   Intel:
     categories:
       - hardware
@@ -2111,6 +2195,12 @@ terms:
   Israel:
     categories:
       - country
+  ISS:
+    expanded_form: International Space Station
+    categories:
+      - space
+      - international
+      - science
   IST:
     expanded_form: Indian Standard Time
     categories:
@@ -2164,6 +2254,9 @@ terms:
   Jekyll:
     categories:
       - static site generator
+    disambiguation:
+      - Jekyll (the Germanic name)
+      - Jekyll (the character in "Strange Case of Dr Jekyll and Mr Hyde")
   Jenkins:
     categories:
       - continuous integration
@@ -2341,6 +2434,7 @@ terms:
     categories:
       - country
       - Europe
+      - Baltic States
   Latvian:
     categories:
       - language
@@ -2405,6 +2499,7 @@ terms:
     categories:
       - country
       - Europe
+      - Baltic States
   Lithuanian:
     categories:
       - language
@@ -2423,6 +2518,11 @@ terms:
   Lotus:
     categories:
       - automotive
+  Lotus Notes:
+    categories:
+      - software
+      - email
+      - collaboration
   LRU:
     expanded_form: Least Recently Used
     categories:
@@ -2445,6 +2545,7 @@ terms:
   MacBook:
     categories:
       - hardware
+      - Apple
   Macedonia:
     categories:
       - country
@@ -2482,6 +2583,7 @@ terms:
   MariaDB:
     categories:
       - database
+      - SQL
   Markdown:
     categories:
       - markup language
@@ -2502,12 +2604,22 @@ terms:
     expanded_form: Middle East and North Africa
     categories:
       - region
+      - Middle East
+      - North Africa
   Mercedes-Benz:
     categories:
       - automotive
   Mercurial:
     categories:
       - version control
+  Meta:
+    expanded_form: Meta Platforms, Inc.
+    categories:
+      - company
+      - GAFAM
+      - Facebook
+      - Instagram
+      - WhatsApp
   Mexican:
     plural: Mexicans
     categories:
@@ -2598,6 +2710,7 @@ terms:
     categories:
       - country
       - Africa
+      - North Africa
   Mozambican:
     categories:
       - language
@@ -2709,7 +2822,7 @@ terms:
       - company
   NetBeans:
     categories:
-      - ide
+      - IDE
   NetBSD:
     categories:
       - operating system
@@ -2935,12 +3048,12 @@ terms:
   OpenSSH:
     expanded_form: Open Secure Shell
     categories:
-      - networking
+      - network
       - security
   OpenSSL:
     expanded_form: Open Secure Sockets Layer
     categories:
-      - networking
+      - network
       - security
   OpenStack:
     categories:
@@ -2960,7 +3073,7 @@ terms:
   OpenVPN:
     expanded_form: Open Virtual Private Network
     categories:
-      - networking
+      - network
   OpenVSX:
     categories:
       - marketplace
@@ -3005,7 +3118,7 @@ terms:
   P2P:
     expanded_form: Peer-to-Peer
     categories:
-      - networking
+      - network
   PaaS:
     expanded_form: Platform as a Service
     categories:
@@ -3083,17 +3196,21 @@ terms:
   PhantomJS:
     categories:
       - web scraping
+      - JavaScript
   Philippines:
     categories:
       - country
       - Asia
   PHing:
     categories:
+      - software
       - build automation
+      - PHP
   PHP:
     expanded_form: PHP Hypertext Preprocessor
     categories:
       - programming language
+      - web
   Pinterest:
     categories:
       - social media
@@ -3235,7 +3352,7 @@ terms:
   QoS:
     expanded_form: Quality of Service
     categories:
-      - networking
+      - network
   R:
     categories:
       - programming language
@@ -3425,6 +3542,12 @@ terms:
     expanded_form: Software as a Service
     categories:
       - deployment model
+  Safari:
+    disambiguation:
+      - safari (the expedition)
+    categories:
+      - web browser
+      - Apple
   Salesforce:
     categories:
       - software
@@ -3433,7 +3556,7 @@ terms:
       - Samba (the music genre)
     categories:
       - software
-      - networking
+      - network
   SAML:
     expanded_form: Security Assertion Markup Language
     categories:
@@ -3469,6 +3592,8 @@ terms:
   Scotland:
     categories:
       - country
+      - Great Britain
+      - United Kingdom
       - Europe
   Scottish:
     categories:
@@ -3548,7 +3673,7 @@ terms:
   SFTP:
     expanded_form: Secure File Transfer Protocol
     categories:
-      - networking
+      - network
       - file transfer
   Shopify:
     categories:
@@ -3601,7 +3726,7 @@ terms:
   SMTP:
     expanded_form: Simple Mail Transfer Protocol
     categories:
-      - networking
+      - network
       - email
   SNMP:
     expanded_form: Simple Network Management Protocol
@@ -3704,17 +3829,17 @@ terms:
   SSH:
     expanded_form: Secure Shell
     categories:
-      - networking
+      - network
       - security
   SSID:
     expanded_form: Service Set Identifier
     categories:
-      - networking
+      - network
       - wireless
   SSL:
     expanded_form: Secure Sockets Layer
     categories:
-      - networking
+      - network
       - security
   SSO:
     expanded_form: Single Sign-On
@@ -3969,7 +4094,7 @@ terms:
     expanded_form: Time To Live
     plural: TTLs
     categories:
-      - networking
+      - network
       - caching
   TTY:
     expanded_form: Teletypewriter
@@ -4103,7 +4228,7 @@ terms:
   UPnP:
     expanded_form: Universal Plug and Play
     categories:
-      - networking
+      - network
       - protocol
   Urdu:
     categories:
@@ -4229,7 +4354,7 @@ terms:
   VLAN:
     expanded_form: Virtual Local Area Network
     categories:
-      - networking
+      - network
   VLC:
     expanded_form: VideoLAN Client
     categories:
@@ -4258,7 +4383,7 @@ terms:
   VPN:
     expanded_form: Virtual Private Network
     categories:
-      - networking
+      - network
   VS Code:
     categories:
       - code editor
@@ -4280,6 +4405,8 @@ terms:
   Wales:
     categories:
       - country
+      - United Kingdom
+      - Great Britain
       - Europe
   WAMP:
     expanded_form: Windows, Apache, MySQL, PHP
@@ -4295,6 +4422,8 @@ terms:
       - web
   watchOS:
     categories:
+      - Apple
+      - iOS
       - operating system
   WebAssembly:
     categories:
@@ -4303,28 +4432,35 @@ terms:
     expanded_form: Web Distributed Authoring and Versioning
     categories:
       - protocol
+      - web
   WebKit:
     categories:
       - browser engine
+      - Safari
   Webpack:
     categories:
       - module bundler
   WebRTC:
+    expanded_form: Web Real-Time Communication
     categories:
       - communication
+      - web
   WebSocket:
     plural: WebSockets
     categories:
       - protocol
+      - web
   WebStorm:
     categories:
       - IDE
   WeChat:
     categories:
       - social network
+      - Asia
   Weibo:
     categories:
       - social network
+      - Asia
   Welsh:
     categories:
       - language
@@ -4349,7 +4485,7 @@ terms:
   Wi-Fi:
     expanded_form: Wireless Fidelity
     categories:
-      - networking
+      - network
   Wikibase:
     categories:
       - knowledge base

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -26,6 +26,13 @@ terms:
   Adwords:
     categories:
       - advertising
+  Afghanistan:
+    categories:
+      - country
+  Africa:
+    categories:
+      - continent
+      - region
   AGPL:
     expanded_form: Affero General Public License
     categories:
@@ -50,6 +57,9 @@ terms:
   Akamai:
     categories:
       - cloud
+  Algeria:
+    categories:
+      - country
   Algolia:
     categories:
       - search
@@ -115,6 +125,14 @@ terms:
     expanded_form: Advanced RISC Machine
     categories:
       - hardware
+  Armenia:
+    categories:
+      - country
+      - Asia
+  Armenian:
+    categories:
+      - language
+      - Armenia
   ASCII:
     expanded_form: American Standard Code for Information Interchange
     categories:
@@ -132,20 +150,51 @@ terms:
   Atlassian:
     categories:
       - company
+  Australia:
+    categories:
+      - country
   AWS:
     expanded_form: Amazon Web Services
     categories:
       - cloud
+  Azerbaijan:
+    categories:
+      - country
+      - Asia
+  Azerbaijani:
+    categories:
+      - language
+      - Azerbaijan
   Azure:
     categories:
       - cloud
   BadgerDB:
     categories:
       - database
+  Bangladesh:
+    categories:
+      - country
+      - Asia
+  Bantu:
+    categories:
+      - language
+      - Africa
   Bash:
     categories:
       - shell
       - programming language
+  Belarus:
+    categories:
+      - country
+      - Europe
+  Belarusian:
+    categories:
+      - language
+      - Belarus
+  Bengali:
+    categories:
+      - language
+      - Bangladesh
   BeOS:
     categories:
       - operating system
@@ -169,6 +218,42 @@ terms:
     categories:
       - operating system
       - Linux distribution
+  Bosnia and Herzegovina:
+    categories:
+      - country
+      - Europe
+  Bosnian:
+    categories:
+      - language
+      - Bosnia and Herzegovina
+  Brazil:
+    categories:
+      - country
+      - South America
+  Brazilian:
+    categories:
+      - language
+      - Brazil
+  BRIC:
+    expanded_form: Brazil, Russia, India, China
+    categories:
+      - region
+      - organization
+  BRICS+:
+    expanded_form: Brazil, Russia, India, China, South Africa
+    categories:
+      - region
+      - organization
+  Britain:
+    categories:
+      - region
+  British:
+    plural: British
+    categories:
+      - language
+      - demonym
+      - nationality
+      - United Kingdom
   Browserify:
     categories:
       - build tool
@@ -194,6 +279,17 @@ terms:
   Btrfs:
     categories:
       - file system
+  Bulgaria:
+    categories:
+      - country
+      - Europe
+  Bulgarian:
+    plural: Bulgarians
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Bulgaria
   C:
     categories:
       - programming language
@@ -210,9 +306,25 @@ terms:
   camelCase:
     categories:
       - programming style
+  Canada:
+    categories:
+      - country
+      - North America
+  Canadian:
+    plural: Canadians
+    categories:
+      - nationality
+      - demonym
+      - language
+      - Canada
   Cassandra:
     categories:
       - database
+  Catalan:
+    categories:
+      - language
+      - Spain
+      - France
   CD-ROM:
     expanded_form: Compact Disc Read-Only Memory
     categories:
@@ -238,6 +350,10 @@ terms:
     categories:
       - artificial intelligence
       - LLM
+  China:
+    categories:
+      - country
+      - Asia
   Chinese:
     categories:
       - language
@@ -289,6 +405,10 @@ terms:
   CoffeeScript:
     categories:
       - programming language
+  Common Wealth:
+    categories:
+      - region
+      - organization
   CommonJS:
     categories:
       - module system
@@ -324,6 +444,14 @@ terms:
     expanded_form: Customer Relationship Management
     categories:
       - software
+  Croatia:
+    categories:
+      - country
+      - Europe
+  Croatian:
+    categories:
+      - language
+      - Croatia
   CRUD:
     expanded_form: Create, Read, Update, Delete
     categories:
@@ -369,6 +497,14 @@ terms:
   Cypress:
     categories:
       - testing
+  Czech:
+    categories:
+      - language
+      - Czech Republic
+  Czech Republic:
+    categories:
+      - country
+      - Europe
   D:
     categories:
       - programming language
@@ -382,6 +518,10 @@ terms:
   Dailymotion:
     categories:
       - video
+  Danish:
+    categories:
+      - language
+      - Denmark
   Dart:
     disambiguation:
       - dart (the game)
@@ -412,6 +552,10 @@ terms:
   Delphi:
     categories:
       - programming language
+  Denmark:
+    categories:
+      - country
+      - Europe
   DevOps:
     categories:
       - software development
@@ -490,6 +634,12 @@ terms:
   DuckDuckGo:
     categories:
       - search
+  Dutch:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Netherlands
   DVD:
     expanded_form: Digital Versatile Disc
     plural: DVDs
@@ -525,6 +675,16 @@ terms:
   EditorConfig:
     categories:
       - configuration
+  Egypt:
+    categories:
+      - country
+      - Africa
+  Egyptian:
+    plural: Egyptians
+    categories:
+      - language
+      - demonym
+      - nationality
   Elasticsearch:
     categories:
       - search
@@ -574,10 +734,26 @@ terms:
       - est (the third person singular form of "to be" in French)
     categories:
       - timezone
+  Estonia:
+    categories:
+      - country
+      - Europe
+  Estonian:
+    plural: Estonians
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Estonia
   ETag:
     expanded_form: Entity Tag
     categories:
       - web development
+  Europe:
+    categories:
+      - continent
+      - region
+      - organization
   Excel:
     categories:
       - software
@@ -610,6 +786,16 @@ terms:
     expanded_form: File Allocation Table 32
     categories:
       - file system
+  Finland:
+    categories:
+      - country
+      - Europe
+  Finnish:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Finland
   Firebase:
     categories:
       - cloud
@@ -654,6 +840,10 @@ terms:
     expanded_form: Fully Qualified Domain Name
     categories:
       - network
+  France:
+    categories:
+      - country
+      - Europe
   FreeBSD:
     categories:
       - operating system
@@ -673,6 +863,11 @@ terms:
     expanded_form: File Transfer Protocol
     categories:
       - protocol
+  GB:
+    expanded_form: Great Britain
+    categories:
+      - country
+      - Europe
   GCP:
     expanded_form: Google Cloud Platform
     categories:
@@ -691,6 +886,25 @@ terms:
   GeoJSON:
     categories:
       - data format
+  Georgia:
+    categories:
+      - country
+  Georgian:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Georgia
+  German:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - German
+  Germany:
+    categories:
+      - country
+      - Europe
   Gherkin:
     categories:
       - programming language
@@ -793,6 +1007,13 @@ terms:
   GraphQL:
     categories:
       - api
+  Great Britain:
+    categories:
+      - region
+  Greece:
+    categories:
+      - country
+      - Europe
   Greek:
     categories:
       - language
@@ -850,12 +1071,19 @@ terms:
     expanded_form: High-Definition Multimedia Interface
     categories:
       - hardware
+  Hebrew:
+    categories:
+      - language
   Helm:
     categories:
       - cloud
   Heroku:
     categories:
       - cloud
+  Hindi:
+    categories:
+      - language
+      - India
   HiveMQ:
     categories:
       - messaging
@@ -902,6 +1130,14 @@ terms:
     expanded_form: HyperText Transfer Protocol Secure
     categories:
       - protocol
+  Hungarian:
+    categories:
+      - language
+      - Hungarian
+  Hungary:
+    categories:
+      - country
+      - Europe
   Hz:
     expanded_form: Hertz
     categories:
@@ -926,6 +1162,15 @@ terms:
     expanded_form: Internet Corporation for Assigned Names and Numbers
     categories:
       - organization
+  Iceland:
+    categories:
+      - country
+      - Europe
+      - Danmark
+  Icelandic:
+    categories:
+      - language
+      - Iceland
   ICMP:
     expanded_form: Internet Control Message Protocol
     categories:
@@ -958,6 +1203,18 @@ terms:
     expanded_form: Indexed Database API
     categories:
       - database
+  India:
+    categories:
+      - country
+      - Asia
+  Indonesia:
+    categories:
+      - country
+      - Asia
+  Indonesian:
+    categories:
+      - language
+      - Indonesia
   InfluxDB:
     expanded_form: Influx Database
     categories:
@@ -1013,6 +1270,9 @@ terms:
     expanded_form: Internet Protocol version 6
     categories:
       - network
+  Iran:
+    categories:
+      - country
   IRIX:
     categories:
       - operating system
@@ -1025,10 +1285,22 @@ terms:
     categories:
       - organization
       - standard
+  Israel:
+    categories:
+      - country
   IST:
     expanded_form: Indian Standard Time
     categories:
       - timezone
+  Italian:
+    plural: Italians
+    categories:
+      - language
+      - Italy
+  Italy:
+    categories:
+      - country
+      - Europe
   iTunes:
     categories:
       - software
@@ -1037,6 +1309,14 @@ terms:
       - Jaeger (the German word for hunter)
     categories:
       - monitoring
+  Japan:
+    categories:
+      - country
+      - Asia
+  Japanese:
+    categories:
+      - language
+      - Japan
   Java:
     disambiguation:
       - Java (the programming language)
@@ -1115,16 +1395,35 @@ terms:
   Kaspersky:
     categories:
       - software
+  Kazakh:
+    categories:
+      - language
+      - Kazakhstan
+  Kazakhstan:
+    categories:
+      - country
+      - Asia
   KeePass:
     categories:
       - software
   Kibana:
     categories:
       - monitoring
+  Kiswahili:
+    categories:
+      - language
+      - Tanzania
   KO:
     expanded_form: Knockout
     categories:
       - martial art
+  Korean:
+    plural: Koreans
+    categories:
+      - language
+      - demonym
+      - nationality
+      - South Korea
   Kotlin:
     categories:
       - programming language
@@ -1157,6 +1456,14 @@ terms:
   Latin:
     categories:
       - language
+  Latvia:
+    categories:
+      - country
+      - Europe
+  Latvian:
+    categories:
+      - language
+      - Latvia
   Launchpad:
     categories:
       - software
@@ -1199,6 +1506,14 @@ terms:
     categories:
       - operating system
       - Linux distribution
+  Lithuania:
+    categories:
+      - country
+      - Europe
+  Lithuanian:
+    categories:
+      - language
+      - Lithuania
   LLM:
     expanded_form: Large Language Model
     plural: LLMs
@@ -1229,6 +1544,14 @@ terms:
   MacBook:
     categories:
       - hardware
+  Macedonia:
+    categories:
+      - country
+      - Europe
+  Macedonian:
+    categories:
+      - language
+      - Macedonia
   macOS:
     categories:
       - operating system
@@ -1239,6 +1562,14 @@ terms:
   Makefile:
     categories:
       - build tool
+  Malay:
+    categories:
+      - language
+      - Malaysia
+  Malaysia:
+    categories:
+      - country
+      - Asia
   MariaDB:
     categories:
       - database
@@ -1249,9 +1580,25 @@ terms:
     expanded_form: Mountain Daylight Time
     categories:
       - timezone
+  MENA:
+    expanded_form: Middle East and North Africa
+    categories:
+      - region
   Mercurial:
     categories:
       - version control
+  Mexican:
+    plural: Mexicans
+    categories:
+      - nationality
+      - demonym
+      - language
+      - Mexico
+  Mexico:
+    categories:
+      - country
+      - city
+      - North America
   MFA:
     expanded_form: Multi-Factor Authentication
     categories:
@@ -1293,6 +1640,30 @@ terms:
   MongoDB:
     categories:
       - database
+  Mongolia:
+    categories:
+      - country
+      - Asia
+  Mongolian:
+    categories:
+      - language
+      - Mongolia
+  Moroccan:
+    categories:
+      - language
+      - Morocco
+  Morocco:
+    categories:
+      - country
+      - Africa
+  Mozambican:
+    categories:
+      - language
+      - Mozambique
+  Mozambique:
+    categories:
+      - country
+      - Africa
   Mozilla:
     categories:
       - company
@@ -1370,6 +1741,10 @@ terms:
   Netflix:
     categories:
       - video
+  Netherlands:
+    categories:
+      - country
+      - Europe
   Netlify:
     categories:
       - hosting
@@ -1402,6 +1777,17 @@ terms:
   Nominatim:
     categories:
       - mapping
+  Norway:
+    categories:
+      - country
+      - Europe
+      - Scandinavia
+  Norwegian:
+    plural: Norwegians
+    categories:
+      - language
+      - nationality
+      - Norway
   NoSQL:
     categories:
       - database
@@ -1437,6 +1823,9 @@ terms:
   Objective-C:
     categories:
       - programming language
+  Oceania:
+    categories:
+      - region
   OCR:
     expanded_form: Optical Character Recognition
     categories:
@@ -1597,10 +1986,18 @@ terms:
     expanded_form: Platform as a Service
     categories:
       - cloud computing
+  Pakistan:
+    categories:
+      - country
+      - Asia
   Parcel:
   PascalCase:
     categories:
       - programming style
+  Pashto:
+    categories:
+      - language
+      - Iran
   PayPal:
     categories:
       - payment
@@ -1633,6 +2030,10 @@ terms:
     expanded_form: Practical Extraction and Reporting Language
     categories:
       - programming language
+  Persian:
+    categories:
+      - language
+      - Iran
   PGP:
     expanded_form: Pretty Good Privacy
     categories:
@@ -1641,6 +2042,10 @@ terms:
   PhantomJS:
     categories:
       - web scraping
+  Philippines:
+    categories:
+      - country
+      - Asia
   PHing:
     categories:
       - build automation
@@ -1672,10 +2077,25 @@ terms:
     categories:
       - package manager
       - JavaScript
+  Poland:
+    categories:
+      - country
+      - Europe
+  Polish:
+    categories:
+      - language
+      - Poland
   POP3:
     expanded_form: Post Office Protocol 3
     categories:
       - email
+  Portugal:
+    categories:
+      - country
+      - Europe
+  Portuguese:
+    categories:
+      - language
   POSIX:
     expanded_form: Portable Operating System Interface
     categories:
@@ -1820,6 +2240,15 @@ terms:
   RocketMQ:
     categories:
       - messaging
+  Romania:
+    categories:
+      - country
+      - Europe
+  Romanian:
+    plural: Romanians
+    categories:
+      - nationality
+      - language
   ROT13:
     expanded_form: Rotate by 13 places
     categories:
@@ -1844,6 +2273,16 @@ terms:
   Ruby on Rails:
     categories:
       - web framework
+  Russia:
+    categories:
+      - country
+      - Europe
+  Russian:
+    plural: Russians
+    categories:
+      - language
+      - demonym
+      - nationality
   Rust:
     categories:
       - programming language
@@ -1881,9 +2320,29 @@ terms:
     expanded_form: Serial Advanced Technology Attachment
     categories:
       - hardware
+  Saudi Arabia:
+    categories:
+      - country
+      - Asia
   Scala:
     categories:
       - programming language
+  Schengen Area:
+    categories:
+      - agreement
+      - region
+      - Europe
+      - organization
+  Scotland:
+    categories:
+      - country
+      - Europe
+  Scottish:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Scotland
   SCSS:
     expanded_form: Sassy CSS
     categories:
@@ -1928,6 +2387,16 @@ terms:
     categories:
       - marketing
       - web
+  Serbia:
+    categories:
+      - country
+      - Europe
+  Serbian:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Serbia
   SFDC:
     expanded_form: Salesforce.com
     categories:
@@ -1947,6 +2416,24 @@ terms:
     categories:
       - communication
       - software
+  Slovak:
+    categories:
+      - language
+      - Slovakia
+  Slovakia:
+    categories:
+      - country
+      - Europe
+  Slovenia:
+    categories:
+      - country
+      - Europe
+  Slovenian:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Slovenia
   SMTP:
     expanded_form: Simple Mail Transfer Protocol
     categories:
@@ -1983,6 +2470,14 @@ terms:
       - software
       - collaboration
       - version control
+  South Korea:
+    categories:
+      - country
+      - Asia
+  Spanish:
+    categories:
+      - language
+      - nationality
   SphinxDoc:
     categories:
       - documentation
@@ -2073,16 +2568,48 @@ terms:
   Swagger:
     categories:
       - API documentation
+  Swahili:
+    categories:
+      - language
+      - Tanzania
   SwayWM:
     categories:
       - window manager
+  Sweden:
+    categories:
+      - country
+      - Europe
+      - Scandinavia
+  Swedish:
+    categories:
+      - language
+      - demonym
+      - nationality
+      - Sweden
   Swift:
     categories:
       - programming language
+  Switzerland:
+    categories:
+      - country
+      - Europe
   Symfony:
     categories:
       - software
       - PHP
+  Tagalog:
+    categories:
+      - language
+      - Philippines
+  Tamil:
+    categories:
+      - language
+      - India
+      - Sri Lanka
+  Tanzania:
+    categories:
+      - country
+      - Africa
   Tcl:
     expanded_form: Tool Command Language
     categories:
@@ -2102,6 +2629,13 @@ terms:
   Tesla:
     categories:
       - automotive
+  Thai:
+    categories:
+      - language
+      - Thailand
+  Thailand:
+    categories:
+      - country
   Thunderbird:
     categories:
       - email
@@ -2166,6 +2700,13 @@ terms:
     expanded_form: Text User Interface
     categories:
       - user interface
+  Turkey:
+    categories:
+      - country
+  Turkish:
+    categories:
+      - language
+      - Türkiye
   TV:
     expanded_form: Television
     categories:
@@ -2180,6 +2721,13 @@ terms:
   TypeScript:
     categories:
       - programming language
+  Türkiye:
+    categories:
+      - country
+  UAE:
+    expanded_form: United Arab Emirates
+    categories:
+      - country
   Uber:
     categories:
       - transportation
@@ -2210,6 +2758,19 @@ terms:
     expanded_form: User Interface
     categories:
       - user interface
+  UK:
+    expanded_form: United Kingdom
+    categories:
+      - country code
+  Ukraine:
+    categories:
+      - country
+      - Europe
+  Ukrainian:
+    plural: Ukrainians
+    categories:
+      - language
+      - Ukraine
   UML:
     expanded_form: Unified Modeling Language
     categories:
@@ -2217,6 +2778,13 @@ terms:
   Unicode:
     categories:
       - encoding
+  United Arab Emirates:
+    categories:
+      - country
+  United Kingdom:
+    categories:
+      - country
+      - Europe
   Unix:
     categories:
       - operating system
@@ -2225,6 +2793,10 @@ terms:
     categories:
       - networking
       - protocol
+  Urdu:
+    categories:
+      - language
+      - Pakistan
   URI:
     expanded_form: Uniform Resource Identifier
     plural: URIs
@@ -2235,6 +2807,11 @@ terms:
     plural: URLs
     categories:
       - web
+  USA:
+    expanded_form: United States of America
+    categories:
+      - country code
+      - North America
   USB:
     expanded_form: Universal Serial Bus
     categories:
@@ -2273,6 +2850,14 @@ terms:
     expanded_form: User Experience
     categories:
       - user interface
+  Uzbek:
+    categories:
+      - language
+      - Uzbekistan
+  Uzbekistan:
+    categories:
+      - country
+      - Asia
   Vagrant:
     categories:
       - virtualization
@@ -2301,6 +2886,14 @@ terms:
     categories:
       - multimedia
       - video
+  Vietnam:
+    categories:
+      - country
+      - Asia
+  Vietnamese:
+    categories:
+      - language
+      - Vietnam
   Vim:
     categories:
       - text editor
@@ -2358,6 +2951,10 @@ terms:
     categories:
       - web development
       - website
+  Wales:
+    categories:
+      - country
+      - Europe
   WAMP:
     expanded_form: Windows, Apache, MySQL, PHP
     categories:
@@ -2398,6 +2995,10 @@ terms:
   Weibo:
     categories:
       - social network
+  Welsh:
+    categories:
+      - language
+      - Wales
   WhatsApp:
     categories:
       - communication

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -57,6 +57,9 @@ terms:
   Akamai:
     categories:
       - cloud
+  Alfa Romeo:
+    categories:
+      - automotive
   Algeria:
     categories:
       - country
@@ -147,9 +150,15 @@ terms:
     expanded_form: Abstract Syntax Tree
     categories:
       - programming
+  Aston Martin:
+    categories:
+      - automotive
   Atlassian:
     categories:
       - company
+  Audi:
+    categories:
+      - automotive
   Australia:
     categories:
       - country
@@ -195,6 +204,9 @@ terms:
     categories:
       - language
       - Bangladesh
+  Bentley:
+    categories:
+      - automotive
   BeOS:
     categories:
       - operating system
@@ -279,6 +291,9 @@ terms:
   Btrfs:
     categories:
       - file system
+  Bugatti:
+    categories:
+      - automotive
   Bulgaria:
     categories:
       - country
@@ -299,6 +314,9 @@ terms:
   C++:
     categories:
       - programming language
+  Cadillac:
+    categories:
+      - automotive
   CalDAV:
     expanded_form: Calendaring Extensions to WebDAV
     categories:
@@ -350,6 +368,15 @@ terms:
     categories:
       - artificial intelligence
       - LLM
+  Chef:
+    disambiguation:
+      - Chef (the profession)
+    categories:
+      - configuration management
+      - automation
+  Chevrolet:
+    categories:
+      - automotive
   China:
     categories:
       - country
@@ -363,6 +390,9 @@ terms:
       - Chrome (the chemical element)
     categories:
       - browser
+  Chrysler:
+    categories:
+      - automotive
   CI:
     expanded_form: Continuous Integration
     categories:
@@ -374,6 +404,9 @@ terms:
   CircleCI:
     categories:
       - continuous integration
+  Citroën:
+    categories:
+      - automotive
   CLI:
     expanded_form: Command Line Interface
     plural: CLIs
@@ -515,6 +548,12 @@ terms:
   DAB/DAB+:
     categories:
       - hardware
+  Dacia:
+    categories:
+      - automotive
+  Daihatsu:
+    categories:
+      - automotive
   Dailymotion:
     categories:
       - video
@@ -556,6 +595,10 @@ terms:
     categories:
       - country
       - Europe
+  Dependabot:
+    categories:
+      - automation
+      - dependency management
   DevOps:
     categories:
       - software development
@@ -620,6 +663,9 @@ terms:
   Doctrine:
     categories:
       - orm
+  Dodge:
+    categories:
+      - automotive
   DOM:
     expanded_form: Document Object Model
     categories:
@@ -627,6 +673,9 @@ terms:
   DOS:
     categories:
       - operating system
+  DS Automobiles:
+    categories:
+      - automotive
   DSA:
     expanded_form: Digital Signature Algorithm
     categories:
@@ -786,6 +835,13 @@ terms:
     expanded_form: File Allocation Table 32
     categories:
       - file system
+  Ferrari:
+    categories:
+      - automotive
+  Fiat:
+    expanded_form: Fabbrica Italiana Automobili Torino
+    categories:
+      - automotive
   Finland:
     categories:
       - country
@@ -815,6 +871,9 @@ terms:
   Font Awesome:
     categories:
       - icon
+  Ford:
+    categories:
+      - automotive
   Fork Awesome:
     categories:
       - icon
@@ -905,6 +964,10 @@ terms:
     categories:
       - country
       - Europe
+  GFM:
+    expanded_form: GitHub Flavored Markdown
+    categories:
+      - markup language
   Gherkin:
     categories:
       - programming language
@@ -942,6 +1005,10 @@ terms:
     expanded_form: Gesellschaft mit beschränkter Haftung
     categories:
       - company category
+  GMC:
+    expanded_form: General Motors Company
+    categories:
+      - automotive
   GMT:
     expanded_form: Greenwich Mean Time
     categories:
@@ -1094,6 +1161,9 @@ terms:
   Homebrew:
     categories:
       - package management
+  Honda:
+    categories:
+      - automotive
   HP-UX:
     expanded_form: Hewlett Packard Unix
     categories:
@@ -1130,6 +1200,9 @@ terms:
     expanded_form: HyperText Transfer Protocol Secure
     categories:
       - protocol
+  Hummer:
+    categories:
+      - automotive
   Hungarian:
     categories:
       - language
@@ -1138,6 +1211,9 @@ terms:
     categories:
       - country
       - Europe
+  Hyundai:
+    categories:
+      - automotive
   Hz:
     expanded_form: Hertz
     categories:
@@ -1215,6 +1291,9 @@ terms:
     categories:
       - language
       - Indonesia
+  Infiniti:
+    categories:
+      - automotive
   InfluxDB:
     expanded_form: Influx Database
     categories:
@@ -1309,6 +1388,9 @@ terms:
       - Jaeger (the German word for hunter)
     categories:
       - monitoring
+  Jaguar:
+    categories:
+      - automotive
   Japan:
     categories:
       - country
@@ -1326,6 +1408,9 @@ terms:
   JavaScript:
     categories:
       - programming language
+  Jeep:
+    categories:
+      - automotive
   Jekyll:
     categories:
       - static site generator
@@ -1395,6 +1480,10 @@ terms:
   Kaspersky:
     categories:
       - software
+  Kawasaki:
+    categories:
+      - automotive
+      - motorcycles
   Kazakh:
     categories:
       - language
@@ -1406,6 +1495,9 @@ terms:
   KeePass:
     categories:
       - software
+  Kia:
+    categories:
+      - automotive
   Kibana:
     categories:
       - monitoring
@@ -1431,10 +1523,16 @@ terms:
     categories:
       - container
       - orchestration
+  Lamborghini:
+    categories:
+      - automotive
   LAN:
     expanded_form: Local Area Network
     categories:
       - network
+  Land Rover:
+    categories:
+      - automotive
   LanguageTool:
     categories:
       - software
@@ -1486,6 +1584,9 @@ terms:
     categories:
       - programming language
       - obfuscation
+  Lexus:
+    categories:
+      - automotive
   LGPL:
     expanded_form: Lesser General Public License
     categories:
@@ -1496,6 +1597,9 @@ terms:
   LibreOffice:
     categories:
       - software
+  Lincoln:
+    categories:
+      - automotive
   LinkedIn:
     categories:
       - social media
@@ -1525,6 +1629,9 @@ terms:
   Logstash:
     categories:
       - data processing
+  Lotus:
+    categories:
+      - automotive
   LRU:
     expanded_form: Least Recently Used
     categories:
@@ -1576,6 +1683,15 @@ terms:
   Markdown:
     categories:
       - markup language
+  Maserati:
+    categories:
+      - automotive
+  Mazda:
+    categories:
+      - automotive
+  McLaren:
+    categories:
+      - automotive
   MDT:
     expanded_form: Mountain Daylight Time
     categories:
@@ -1584,6 +1700,9 @@ terms:
     expanded_form: Middle East and North Africa
     categories:
       - region
+  Mercedes-Benz:
+    categories:
+      - automotive
   Mercurial:
     categories:
       - version control
@@ -1609,6 +1728,9 @@ terms:
   Microsoft Windows:
     categories:
       - operating system
+  Mini:
+    categories:
+      - automotive
   MINIX:
     categories:
       - operating system
@@ -1619,6 +1741,10 @@ terms:
     expanded_form: Massachusetts Institute of Technology
     categories:
       - education
+  Mitsubishi:
+    categories:
+      - automotive
+      - motorcycles
   MLOps:
     expanded_form: Machine Learning Operations
     categories:
@@ -1766,6 +1892,9 @@ terms:
   nginx:
     categories:
       - web server
+  Nissan:
+    categories:
+      - automotive
   NIST:
     expanded_form: National Institute of Standards and Technology
     categories:
@@ -1854,6 +1983,9 @@ terms:
     expanded_form: Object-Oriented Programming
     categories:
       - programming
+  Opel:
+    categories:
+      - automotive
   OpenAI:
     expanded_form: Open Artificial Intelligence
     categories:
@@ -1986,6 +2118,9 @@ terms:
     expanded_form: Platform as a Service
     categories:
       - cloud computing
+  Pagani:
+    categories:
+      - automotive
   Pakistan:
     categories:
       - country
@@ -2034,6 +2169,9 @@ terms:
     categories:
       - language
       - Iran
+  Peugeot:
+    categories:
+      - automotive
   PGP:
     expanded_form: Pretty Good Privacy
     categories:
@@ -2085,10 +2223,16 @@ terms:
     categories:
       - language
       - Poland
+  Pontiac:
+    categories:
+      - automotive
   POP3:
     expanded_form: Post Office Protocol 3
     categories:
       - email
+  Porsche:
+    categories:
+      - automotive
   Portugal:
     categories:
       - country
@@ -2210,6 +2354,9 @@ terms:
     expanded_form: Reiser File System
     categories:
       - file system
+  Renault:
+    categories:
+      - automotive
   RequireJS:
     categories:
       - JavaScript
@@ -2291,6 +2438,10 @@ terms:
   Rustup:
     categories:
       - software
+  Saab:
+    expanded_form: Svenska Aeroplan Aktiebolaget
+    categories:
+      - automotive
   SaaS:
     expanded_form: Software as a Service
     categories:
@@ -2366,6 +2517,10 @@ terms:
     expanded_form: Secure Digital eXtended Capacity
     categories:
       - hardware
+  Seat:
+    expanded_form: Sociedad Española de Automóviles de Turismo
+    categories:
+      - automotive
   Selenium:
     disambiguation:
       - Selenium (the chemical element)
@@ -2434,6 +2589,11 @@ terms:
       - demonym
       - nationality
       - Slovenia
+  Smart:
+    disambiguation:
+      - smart (the adjective)
+    categories:
+      - automotive
   SMTP:
     expanded_form: Simple Mail Transfer Protocol
     categories:
@@ -2543,6 +2703,13 @@ terms:
   StandardJS:
     categories:
       - software
+  Stellantis:
+    categories:
+      - automotive
+      - group
+  Subaru:
+    categories:
+      - automotive
   Sublime Text:
     categories:
       - text editor
@@ -2556,6 +2723,9 @@ terms:
     expanded_form: Software und System-Entwicklung
     categories:
       - operating system
+  Suzuki:
+    categories:
+      - automotive
   SVG:
     expanded_form: Scalable Vector Graphics
     categories:
@@ -2610,6 +2780,9 @@ terms:
     categories:
       - country
       - Africa
+  Tata:
+    categories:
+      - automotive
   Tcl:
     expanded_form: Tool Command Language
     categories:
@@ -2664,6 +2837,9 @@ terms:
     expanded_form: Time-based One-Time Password
     categories:
       - security
+  Toyota:
+    categories:
+      - automotive
   Traefik:
     categories:
       - reverse proxy
@@ -2871,6 +3047,9 @@ terms:
     categories:
       - security
       - secrets management
+  Vauxhall:
+    categories:
+      - automotive
   VCS:
     expanded_form: Version Control System
     categories:
@@ -2929,6 +3108,12 @@ terms:
     categories:
       - remote desktop
       - protocol
+  Volkswagen:
+    categories:
+      - automotive
+  Volvo:
+    categories:
+      - automotive
   VPN:
     expanded_form: Virtual Private Network
     categories:
@@ -3129,3 +3314,6 @@ terms:
     expanded_form: Z Shell
     categories:
       - shell
+  Škoda:
+    categories:
+      - automotive

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -52,6 +52,7 @@ terms:
   Alpine:
     categories:
       - operating system
+      - Linux distribution
   Altassian:
     categories:
       - software
@@ -208,6 +209,7 @@ terms:
     expanded_form: Community ENTerprise Operating System
     categories:
       - operating system
+      - Linux distribution
   CERT:
     expanded_form: Computer Emergency Response Team
     categories:
@@ -215,9 +217,11 @@ terms:
   ChatGPT:
     categories:
       - artificial intelligence
+      - LLM
   Chinese:
     categories:
       - language
+      - China
   Chrome:
     disambiguation:
       - Chrome (the chemical element)
@@ -280,6 +284,7 @@ terms:
   CoreOS:
     categories:
       - operating system
+      - Linux distribution
   CORS:
     expanded_form: Cross-Origin Resource Sharing
     categories:
@@ -353,7 +358,7 @@ terms:
     expanded_form: Database Administrator
     plural: DBAs
     categories:
-      - jobs
+      - job role
       - database
   DBus:
     expanded_form: Desktop Bus
@@ -367,6 +372,7 @@ terms:
   Debian:
     categories:
       - operating system
+      - Linux distribution
   Deezer:
     categories:
       - music
@@ -376,12 +382,12 @@ terms:
   DevOps:
     categories:
       - software development
-      - jobs
+      - job role
   DevSecOps:
     categories:
       - software development
       - security
-      - jobs
+      - job role
   Dgraph:
     categories:
       - database
@@ -491,7 +497,7 @@ terms:
   Elixir:
     disambiguation:
       - Elixir (the programming language)
-      - Elixir (the potion)
+      - elixir (the potion)
     categories:
       - programming language
   EMEA:
@@ -520,7 +526,7 @@ terms:
     expanded_form: ECMAScript Lint
     categories:
       - linting
-      - javascript
+      - JavaScript
   ESSID:
     expanded_form: Extended Service Set Identifier
     categories:
@@ -620,6 +626,7 @@ terms:
       - language
       - demonym
       - nationality
+      - France
   FTP:
     expanded_form: File Transfer Protocol
     categories:
@@ -644,7 +651,9 @@ terms:
       - data format
   Gherkin:
     categories:
-      - language
+      - programming language
+      - behavior-driven development
+      - testing
   GHz:
     expanded_form: Gigahertz
     categories:
@@ -665,9 +674,11 @@ terms:
   GitLab:
     categories:
       - software
+      - version control
   GitLab CI:
     categories:
       - continuous integration
+      - GitLab
   GlassFish:
     categories:
       - web server
@@ -740,6 +751,7 @@ terms:
   Greek:
     categories:
       - language
+      - Greece
   Groovy:
     categories:
       - programming language
@@ -900,7 +912,7 @@ terms:
       - database
   Insomnia:
     disambiguation:
-      - Insomnia (the sleep disorder)
+      - insomnia (the sleep disorder)
     categories:
       - software
   Instagram:
@@ -957,6 +969,7 @@ terms:
     expanded_form: International Organization for Standardization
     categories:
       - organization
+      - standard
   IST:
     expanded_form: Indian Standard Time
     categories:
@@ -1035,6 +1048,7 @@ terms:
     categories:
       - security
       - authentication
+      - authorization
   Kafka:
     disambiguation:
       - Kafka (the author)
@@ -1177,7 +1191,7 @@ terms:
     expanded_form: Machine Learning Operations
     categories:
       - machine learning
-      - jobs
+      - job role
   MochaJS:
     categories:
       - testing
@@ -1187,7 +1201,7 @@ terms:
   Moment.js:
     categories:
       - date
-      - javascript library
+      - JavaScript library
   Mongo:
     categories:
       - database
@@ -1229,6 +1243,8 @@ terms:
       - architecture
   MVP:
     expanded_form: Minimum Viable Product
+    categories:
+      - product development
   MyRocks:
     categories:
       - database
@@ -1323,71 +1339,162 @@ terms:
       - financial
   OAuth:
     expanded_form: Open Authorization
+    categories:
+      - authentication
+      - identity
+      - authorization
   OAuth 2.0:
+    expanded_form: Open Authorization 2.0
+    categories:
+      - authentication
+      - identity
+      - authorization
   Objective-C:
+    categories:
+      - programming language
   OCR:
     expanded_form: Optical Character Recognition
+    categories:
+      - computer vision
   OIDC:
     expanded_form: OpenID Connect
+    categories:
+      - authentication
   OK:
     expanded_form: Zero Kill (originally a military term)
+    categories:
+      - general
   OLAP:
     expanded_form: Online Analytical Processing
+    categories:
+      - database
   OLTP:
     expanded_form: Online Transaction Processing
+    categories:
+      - database
   OOM:
     expanded_form: Out Of Memory
+    categories:
+      - programming
   OpenAI:
     expanded_form: Open Artificial Intelligence
+    categories:
+      - artificial intelligence
   OpenAPI:
     expanded_form: Open Application Programming Interface
+    categories:
+      - api
+      - web development
   OpenBSD:
     expanded_form: Open Berkeley Software Distribution
+    categories:
+      - operating system
   OpenCart:
+    categories:
+      - e-commerce
   OpenCensus:
+    categories:
+      - observability
   OpenCollective:
+    categories:
+      - funding
   OpenGL:
     expanded_form: Open Graphics Library
+    categories:
+      - graphics
   OpenID:
     expanded_form: Open Identity
+    categories:
+      - authentication
   OpenJDK:
     expanded_form: Open Java Development Kit
+    categories:
+      - programming
   OpenMetrics:
+    categories:
+      - observability
   OpenOffice:
+    categories:
+      - office suite
   OpenPGP:
     expanded_form: Open Pretty Good Privacy
+    categories:
+      - encryption
   OpenSearch:
+    categories:
+      - search
   OpenShift:
+    categories:
+      - container
+      - orchestration
   OpenSolaris:
+    categories:
+      - operating system
   OpenSSH:
     expanded_form: Open Secure Shell
+    categories:
+      - networking
+      - security
   OpenSSL:
     expanded_form: Open Secure Sockets Layer
+    categories:
+      - networking
+      - security
   OpenStack:
+    categories:
+      - cloud
+      - orchestration
   openSUSE:
     expanded_form: Open Software und System-Entwicklung
+    categories:
+      - operating system
   OpenTelemetry:
+    categories:
+      - observability
   OpenTSDB:
     expanded_form: Open Time Series Database
+    categories:
+      - database
   OpenVPN:
     expanded_form: Open Virtual Private Network
+    categories:
+      - networking
   OpenVSX:
+    categories:
+      - marketplace
   OpenVZ:
+    categories:
+      - virtualization
   Oracle:
     disambiguation:
-      - Oracle (the company)
-      - Oracle (Greek mythology)
+      - oracle (divination)
+    categories:
+      - database
+      - company
   ORM:
     expanded_form: Object-Relational Mapping
+    categories:
+      - database
   OSM:
     expanded_form: OpenStreetMap
+    categories:
+      - mapping
   OSS:
     expanded_form: Open Source Software
+    categories:
+      - software
   OTel:
     expanded_form: OpenTelemetry
+    categories:
+      - observability
   OTLP:
     expanded_form: OpenTelemetry Protocol
+    categories:
+      - observability
   OVH:
+    categories:
+      - cloud
+      - hosting
   OWASP:
     expanded_form: Open Web Application Security Project
     categories:
@@ -1395,8 +1502,12 @@ terms:
       - security
   P2P:
     expanded_form: Peer-to-Peer
+    categories:
+      - networking
   PaaS:
     expanded_form: Platform as a Service
+    categories:
+      - cloud computing
   Parcel:
   PascalCase:
     categories:
@@ -1406,44 +1517,83 @@ terms:
       - payment
   PCRE:
     expanded_form: Perl Compatible Regular Expressions
+    categories:
+      - programming language
   PCRE1:
     expanded_form: Perl Compatible Regular Expressions version 1
+    categories:
+      - programming language
   PCRE2:
     expanded_form: Perl Compatible Regular Expressions version 2
+    categories:
+      - programming language
   PCT:
     expanded_form: Pacific Time
+    categories:
+      - timezone
   PDF:
     expanded_form: Portable Document Format
+    categories:
+      - document
+      - file format
   Percona:
+    categories:
+      - company
+      - database
   Perl:
     expanded_form: Practical Extraction and Reporting Language
+    categories:
+      - programming language
   PGP:
     expanded_form: Pretty Good Privacy
+    categories:
+      - encryption
+      - security
   PhantomJS:
+    categories:
+      - web scraping
   PHing:
+    categories:
+      - build automation
   PHP:
     expanded_form: PHP Hypertext Preprocessor
+    categories:
+      - programming language
   Pinterest:
+    categories:
+      - social media
+      - image sharing
   PIPL:
     expanded_form: Personal Information Protection Law
     categories:
       - regulation
   'PKCS #12':
     expanded_form: Public-Key Cryptography Standards
+    categories:
+      - encryption
   PlayStation:
+    categories:
+      - gaming
   PNG:
     expanded_form: Portable Network Graphics
     categories:
       - image format
       - file extension
   pnpm:
+    categories:
+      - package manager
+      - JavaScript
   POP3:
     expanded_form: Post Office Protocol 3
     categories:
       - email
   POSIX:
     expanded_form: Portable Operating System Interface
+    categories:
+      - standard
   Postgres:
+    categories:
+      - database
   PostgreSQL:
     categories:
       - database
@@ -1457,9 +1607,14 @@ terms:
   Prettier:
     disambiguation:
       - prettier (the adjective)
+    categories:
+      - code formatting
   Prometheus:
     disambiguation:
       - Prometheus (the Greek mythological figure)
+    categories:
+      - monitoring
+      - observability
   PubSub:
     expanded_form: Publish-Subscribe
     categories:
@@ -1478,18 +1633,28 @@ terms:
     categories:
       - security
   PyCharm:
+    categories:
+      - IDE
+      - Python
   PyPI:
     expanded_form: Python Package Index
   Python:
     categories:
       - programming language
     disambiguation:
-      - Python (the snake)
+      - python (the snake)
   PyTorch:
+    categories:
+      - machine learning
+      - deep learning
   PyYAML:
     expanded_form: Python YAML
+    categories:
+      - data serialization
   QoS:
     expanded_form: Quality of Service
+    categories:
+      - networking
   R:
     categories:
       - programming language
@@ -1507,133 +1672,287 @@ terms:
       - hardware
   React:
     disambiguation:
-      - React (the verb)
+      - react (the verb)
+    categories:
+      - web framework
+      - JavaScript
   Red Hat:
+    categories:
+      - company
+      - operating system
+      - Linux distribution
   Reddit:
+    categories:
+      - social media
   Redis:
+    categories:
+      - database
   Redux:
+    categories:
+      - state management
   RefluxJS:
   ReiserFS:
+    expanded_form: Reiser File System
+    categories:
+      - file system
   RequireJS:
+    categories:
+      - JavaScript
+      - module loader
   RESTful:
     categories:
       - architectural style
   reStructuredText:
+    categories:
+      - markup language
+      - documentation
   RFC:
     expanded_form: Request for Comments
+    categories:
+      - document
   RGB:
     expanded_form: Red Green Blue
+    categories:
+      - color
   RGBA:
     expanded_form: Red Green Blue Alpha
+    categories:
+      - color
   RHEL:
     expanded_form: Red Hat Enterprise Linux
+    categories:
+      - operating system
   RocketMQ:
+    categories:
+      - messaging
   ROT13:
     expanded_form: Rotate by 13 places
     categories:
       - obfuscation
   RPC:
     expanded_form: Remote Procedure Call
+    categories:
+      - network
   RSA:
     expanded_form: Rivest–Shamir–Adleman
     categories:
       - cryptography
   RSS:
     expanded_form: Really Simple Syndication
+    categories:
+      - communication
   Ruby:
     disambiguation:
-      - Ruby (the gemstone)
+      - ruby (the gemstone)
     categories:
       - programming language
   Ruby on Rails:
+    categories:
+      - web framework
   Rust:
     categories:
       - programming language
     disambiguation:
-      - Rust (the corroded metal)
+      - rust (the corroded metal)
   Rustup:
+    categories:
+      - software
   SaaS:
     expanded_form: Software as a Service
+    categories:
+      - deployment model
   Salesforce:
+    categories:
+      - software
   Samba:
     disambiguation:
       - Samba (the music genre)
+    categories:
+      - software
+      - networking
   SAML:
     expanded_form: Security Assertion Markup Language
     categories:
       - authentication
   SASL:
     expanded_form: Simple Authentication and Security Layer
+    categories:
+      - authentication
   Sass:
     expanded_form: Syntactically Awesome Style Sheets
+    categories:
+      - styling
   SATA:
     expanded_form: Serial Advanced Technology Attachment
+    categories:
+      - hardware
   Scala:
+    categories:
+      - programming language
   SCSS:
     expanded_form: Sassy CSS
+    categories:
+      - styling
   ScyllaDB:
+    categories:
+      - database
   SDHC:
     expanded_form: Secure Digital High Capacity
+    categories:
+      - hardware
   SDK:
     expanded_form: Software Development Kit
+    categories:
+      - software
   SDUC:
     expanded_form: Secure Digital Ultra Capacity
+    categories:
+      - hardware
   SDXC:
     expanded_form: Secure Digital eXtended Capacity
+    categories:
+      - hardware
   Selenium:
     disambiguation:
       - Selenium (the chemical element)
+    categories:
+      - software
+      - testing
   SELinux:
     expanded_form: Security-Enhanced Linux
+    categories:
+      - security
+      - Linux
   SemVer:
+    expanded_form: Semantic Versioning
+    categories:
+      - versioning
+      - standard
   SEO:
     expanded_form: Search Engine Optimization
+    categories:
+      - marketing
+      - web
   SFDC:
     expanded_form: Salesforce.com
+    categories:
+      - software
   SFTP:
     expanded_form: Secure File Transfer Protocol
+    categories:
+      - networking
+      - file transfer
   SLA:
+    plural: SLAs
     expanded_form: Service Level Agreement
+    categories:
+      - business
+      - document
   Slack:
     categories:
       - communication
       - software
   SMTP:
     expanded_form: Simple Mail Transfer Protocol
+    categories:
+      - networking
+      - email
   SOAP:
     expanded_form: Simple Object Access Protocol
+    categories:
+      - web services
   Solaris:
+    categories:
+      - operating system
   SolidJS:
+    categories:
+      - JavaScript
   Solr:
+    categories:
+      - search
   SonarQube:
+    categories:
+      - software
+      - monitoring
   SOQL:
     expanded_form: Salesforce Object Query Language
+    categories:
+      - database
+      - query language
   SoundCloud:
+    categories:
+      - audio
+      - music
   SourceForge:
+    categories:
+      - software
+      - collaboration
+      - version control
   SphinxDoc:
+    categories:
+      - documentation
   Spotify:
+    categories:
+      - audio
+      - music
   SQL:
     expanded_form: Structured Query Language
+    categories:
+      - database
+      - query language
   SQLAlchemy:
+    categories:
+      - software
   SQLite:
+    categories:
+      - database
   SQLite3:
+    categories:
+      - database
   SQLServer:
+    categories:
+      - database
   SRE:
     expanded_form: Site Reliability Engineer
     plural: SREs
+    categories:
+      - job role
   SSD:
     expanded_form: Solid State Drive
+    categories:
+      - storage
+      - hardware
   SSH:
     expanded_form: Secure Shell
+    categories:
+      - networking
+      - security
   SSID:
     expanded_form: Service Set Identifier
+    categories:
+      - networking
+      - wireless
   SSL:
     expanded_form: Secure Sockets Layer
+    categories:
+      - networking
+      - security
   SSO:
     expanded_form: Single Sign-On
+    categories:
+      - security
+      - identity
   Stack Exchange:
+    categories:
+      - community
+      - Q&A
   Stack Overflow:
+    categories:
+      - community
+      - Q&A
   StandardJS:
+    categories:
+      - software
   Sublime Text:
     categories:
       - text editor
@@ -1657,14 +1976,34 @@ terms:
     categories:
       - version control
   Swagger:
+    categories:
+      - API documentation
   SwayWM:
+    categories:
+      - window manager
   Swift:
+    categories:
+      - programming language
   Symfony:
+    categories:
+      - software
+      - PHP
   Tcl:
+    expanded_form: Tool Command Language
+    categories:
+      - programming language
   TCP:
     expanded_form: Transmission Control Protocol
+    categories:
+      - networking
   TensorFlow:
+    categories:
+      - machine learning
+      - software
   Terraform:
+    categories:
+      - infrastructure as code
+      - software
   Tesla:
     categories:
       - automotive
@@ -1685,6 +2024,8 @@ terms:
       - security
   ToC:
     expanded_form: Table of Contents
+    categories:
+      - documentation
   TOML:
     expanded_form: Tom's Obvious, Minimal Language
     categories:
@@ -1724,10 +2065,16 @@ terms:
       - caching
   TTY:
     expanded_form: Teletypewriter
+    categories:
+      - terminal
   TUI:
     expanded_form: Text User Interface
+    categories:
+      - user interface
   TV:
     expanded_form: Television
+    categories:
+      - media
   tvOS:
     expanded_form: Television Operating System
     categories:
@@ -1744,15 +2091,24 @@ terms:
   Ubuntu:
     categories:
       - operating system
+      - Linux distribution
   UbuntuCE:
+    categories:
+      - operating system
+      - Linux distribution
+      - Ubuntu variant
   UDP:
     expanded_form: User Datagram Protocol
+    categories:
+      - networking
   UEFI:
     expanded_form: Unified Extensible Firmware Interface
     categories:
       - firmware
   UI:
     expanded_form: User Interface
+    categories:
+      - user interface
   UML:
     expanded_form: Unified Modeling Language
     categories:
@@ -1765,19 +2121,36 @@ terms:
       - operating system
   UPnP:
     expanded_form: Universal Plug and Play
+    categories:
+      - networking
+      - protocol
   URI:
     expanded_form: Uniform Resource Identifier
     plural: URIs
+    categories:
+      - web
   URL:
     expanded_form: Uniform Resource Locator
     plural: URLs
+    categories:
+      - web
   USB:
     expanded_form: Universal Serial Bus
+    categories:
+      - hardware
   USB Type-A:
+    categories:
+      - hardware
   USB Type-B:
+    categories:
+      - hardware
   USB Type-C:
+    categories:
+      - hardware
   UTC:
     expanded_form: Coordinated Universal Time
+    categories:
+      - timezone
   UTF-16:
     expanded_form: Unicode Transformation Format 16-bit
     categories:
@@ -1789,8 +2162,12 @@ terms:
   UUID:
     expanded_form: Universally Unique Identifier
     plural: UUIDs
+    categories:
+      - identifier
   UX:
     expanded_form: User Experience
+    categories:
+      - user interface
   Vagrant:
     categories:
       - virtualization
@@ -1810,8 +2187,15 @@ terms:
       - software development
       - version control
   Vercel:
+    categories:
+      - cloud platform
   Verizon:
+    categories:
+      - telecommunications
   VideoLAN:
+    categories:
+      - multimedia
+      - video
   Vim:
     categories:
       - text editor
@@ -1822,6 +2206,8 @@ terms:
     categories:
       - code editor
   VKontakte:
+    categories:
+      - social network
   VLAN:
     expanded_form: Virtual Local Area Network
     categories:
@@ -1853,22 +2239,34 @@ terms:
     categories:
       - code editor
   vSphere:
+    categories:
+      - virtualization
   W3C:
     expanded_form: World Wide Web Consortium
+    categories:
+      - web
   W3M:
     expanded_form: World Wide Web for Unix
+    categories:
+      - web
   W3Schools:
     categories:
       - web development
       - website
   WAMP:
     expanded_form: Windows, Apache, MySQL, PHP
+    categories:
+      - software stack
   Wasm:
     expanded_form: WebAssembly
+    categories:
+      - web
   watchOS:
     categories:
       - operating system
   WebAssembly:
+    categories:
+      - web
   WebDAV:
     expanded_form: Web Distributed Authoring and Versioning
     categories:
@@ -1877,28 +2275,52 @@ terms:
     categories:
       - browser engine
   Webpack:
+    categories:
+      - module bundler
   WebRTC:
+    categories:
+      - communication
   WebSocket:
     plural: WebSockets
+    categories:
+      - protocol
   WebStorm:
+    categories:
+      - IDE
   WeChat:
+    categories:
+      - social network
   Weibo:
+    categories:
+      - social network
   WhatsApp:
     categories:
       - communication
+      - software
   Wi-Fi:
     expanded_form: Wireless Fidelity
+    categories:
+      - networking
   Wikibase:
+    categories:
+      - knowledge base
   Wikidata:
+    categories:
+      - knowledge base
   Wikipedia:
     categories:
       - encyclopedia
   Wikitext:
+    categories:
+      - markup language
   Windows:
     categories:
       - operating system
   WMA:
     expanded_form: Windows Media Audio
+    categories:
+      - audio
+      - file format
   WordPress:
     categories:
       - content management system
@@ -1909,44 +2331,90 @@ terms:
       - virtualization
   WWDC:
     expanded_form: Worldwide Developers Conference
+    categories:
+      - conference
+      - web
   X:
     categories:
       - social network
   X.509:
     expanded_form: ITU-T X.509 standard for public key certificates
+    categories:
+      - security
   XAMPP:
     expanded_form: Cross-Platform, Apache, MySQL, PHP, Perl
+    categories:
+      - software stack
   Xcode:
+    categories:
+      - IDE
   XDG:
     expanded_form: X Desktop Group
+    categories:
+      - standard
   XFCE:
     expanded_form: XForms Common Environment
     categories:
       - desktop environment
   XFS:
     expanded_form: X File System
+    categories:
+      - file system
   XHTML:
     expanded_form: Extensible HyperText Markup Language
+    categories:
+      - markup language
   XML:
     expanded_form: Extensible Markup Language
+    categories:
+      - markup language
   XMLHttpRequest:
+    categories:
+      - web
+      - API
   XSL:
     expanded_form: Extensible Stylesheet Language
+    categories:
+      - markup language
   XSLT:
     expanded_form: Extensible Stylesheet Language Transformations
+    categories:
+      - markup language
   XSS:
     expanded_form: Cross-Site Scripting
+    categories:
+      - security
   XtraBackup:
+    categories:
+      - backup
   YAML:
     expanded_form: YAML Ain't Markup Language
+    categories:
+      - markup language
   Yarn:
+    categories:
+      - package manager
   YML:
     expanded_form: YAML Markup Language
+    categories:
+      - markup language
   YouTube:
+    categories:
+      - video
   ZFS:
     expanded_form: Zettabyte File System
+    categories:
+      - file system
   Zipkin:
+    categories:
+      - distributed tracing
   zlib:
+    categories:
+      - compression
   ZooKeeper:
+    categories:
+      - distributed systems
   Zsh:
     expanded_form: Z Shell
+    categories:
+      - shell

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -110,9 +110,19 @@ terms:
   Amazon:
     categories:
       - company
+      - GAFAM
+  Amazon CloudFormation:
+    categories:
+      - cloud
+  Amazon CloudFront:
+    categories:
+      - cloud
   Amazon DynamoDB:
     categories:
       - database
+  Amazon S3:
+    categories:
+      - cloud
   AMQP:
     expanded_form: Advanced Message Queuing Protocol
     categories:
@@ -229,6 +239,21 @@ terms:
       - software
   AWS:
     expanded_form: Amazon Web Services
+    categories:
+      - cloud
+  AWS Amplify:
+    categories:
+      - cloud
+  AWS AppSync:
+    categories:
+      - cloud
+  AWS CloudTrail:
+    categories:
+      - cloud
+  AWS CodePipeline:
+    categories:
+      - cloud
+  AWS Lambda:
     categories:
       - cloud
   Azerbaijan:
@@ -868,6 +893,10 @@ terms:
     expanded_form: European Article Number
     categories:
       - standard
+  EC2:
+    expanded_form: Amazon Elastic Compute Cloud
+    categories:
+      - cloud
   ECMAScript:
     categories:
       - programming language
@@ -979,6 +1008,10 @@ terms:
   F#:
     categories:
       - programming language
+  FaaS:
+    expanded_form: Function as a Service
+    categories:
+      - cloud
   Facebook:
     categories:
       - social media
@@ -1222,6 +1255,17 @@ terms:
   Google:
     categories:
       - company
+  Google Cloud Functions:
+    categories:
+      - cloud
+      - Google
+  Google Cloud Platform:
+    categories:
+      - cloud
+      - Google
+  Google Drive:
+    categories:
+      - cloud
   Google Suite:
     categories:
       - software
@@ -1424,6 +1468,10 @@ terms:
     expanded_form: Internationalization (with 18 letters between I and n)
     categories:
       - localization
+  IaaS:
+    expanded_form: Infrastructure as a Service
+    categories:
+      - cloud
   IANA:
     expanded_form: Internet Assigned Numbers Authority
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -77,6 +77,9 @@ terms:
     categories:
       - technology
       - artificial intelligence
+  Airflow:
+    categories:
+      - data processing
   AirPods:
     categories:
       - hardware
@@ -129,6 +132,12 @@ terms:
   Amazon S3:
     categories:
       - cloud
+  American:
+    plural: Americans
+    categories:
+      - nationality
+      - demonym
+      - USA
   AMQP:
     expanded_form: Advanced Message Queuing Protocol
     categories:
@@ -154,15 +163,57 @@ terms:
       - Apache (the Native American tribe)
     categories:
       - software
+  Apache Ant:
+    categories:
+      - build tool
   Apache Cassandra:
     categories:
       - database
+  Apache Cordova:
+    categories:
+      - mobile framework
   Apache CouchDB:
     categories:
       - database
+  Apache Flink:
+    categories:
+      - data processing
+  Apache HTTP Server:
+    categories:
+      - web server
+  Apache Kafka:
+    categories:
+      - messaging
+  Apache Lucene:
+    categories:
+      - search
+  Apache Maven:
+    categories:
+      - build tool
+  Apache Nifi:
+    categories:
+      - data processing
   Apache OpenNLP:
     categories:
       - natural language processing
+  Apache Pig:
+    categories:
+      - data processing
+  Apache Pulsar:
+    categories:
+      - messaging
+  Apache Solr:
+    categories:
+      - search
+  Apache Spark:
+    categories:
+      - data processing
+  Apache Struts:
+    categories:
+      - web framework
+  Apache Tomcat:
+    categories:
+      - web server
   APFS:
     expanded_form: Apple File System
     categories:
@@ -206,6 +257,9 @@ terms:
     expanded_form: Address Resolution Protocol
     categories:
       - network
+  Artifactory:
+    categories:
+      - repository
   Asana:
     categories:
       - software
@@ -216,6 +270,9 @@ terms:
   AsciiDoc:
     categories:
       - markup language
+  ASP:
+    categories:
+      - web framework
   Assembly:
     categories:
       - programming language
@@ -249,12 +306,20 @@ terms:
   Australia:
     categories:
       - country
+  Australian:
+    plural: Australians
+    categories:
+      - nationality
+      - demonym
   Auth0:
     categories:
       - authentication
   AutoCAD:
     categories:
       - software
+  AutoML:
+    categories:
+      - machine learning
   AWS:
     expanded_form: Amazon Web Services
     categories:
@@ -296,6 +361,9 @@ terms:
     categories:
       - language
       - Africa
+  Basecamp:
+    categories:
+      - project management
   Bash:
     categories:
       - shell
@@ -341,6 +409,10 @@ terms:
   Berkeley DB:
     categories:
       - database
+  BFF:
+    expanded_form: Backend For Frontend
+    categories:
+      - architecture
   BGP:
     expanded_form: Border Gateway Protocol
     categories:
@@ -380,6 +452,9 @@ terms:
     categories:
       - operating system
       - Linux distribution
+  Bootstrap:
+    categories:
+      - web framework
   Bosnia and Herzegovina:
     categories:
       - country
@@ -388,6 +463,9 @@ terms:
     categories:
       - language
       - Bosnia and Herzegovina
+  Bower:
+    categories:
+      - package management
   Brazil:
     categories:
       - country
@@ -416,6 +494,12 @@ terms:
       - demonym
       - nationality
       - United Kingdom
+  Brother:
+    disambiguation:
+      - brother (the family relation)
+    categories:
+      - hardware
+      - printing
   Browserify:
     categories:
       - build tool
@@ -459,6 +543,10 @@ terms:
       - demonym
       - nationality
       - Bulgaria
+  BYOD:
+    expanded_form: Bring Your Own Device
+    categories:
+      - technology
   C:
     categories:
       - programming language
@@ -489,11 +577,30 @@ terms:
       - demonym
       - language
       - Canada
+  Canon:
+    disambiguation:
+      - canon (military)
+    categories:
+      - hardware
+      - printing
+  CAP:
+    expanded_form: Consistency, Availability, Partition Tolerance
+    categories:
+      - architecture
+  Capacitor:
+    categories:
+      - framework
   CAPTCHA:
     expanded_form: Completely Automated Public Turing test to tell Computers and Humans Apart
     plural: CAPTCHAs
     categories:
       - authentication
+  Cardano:
+    categories:
+      - cryptocurrency
+  Cargo:
+    categories:
+      - build tool
   Caspio:
     categories:
       - database
@@ -521,6 +628,9 @@ terms:
     expanded_form: Content Delivery Network
     categories:
       - network
+  Celery:
+    categories:
+      - task queue
   CentOS:
     expanded_form: Community ENTerprise Operating System
     categories:
@@ -567,6 +677,9 @@ terms:
       - Chrome (the chemical element)
     categories:
       - browser
+  Chromium:
+    categories:
+      - browser
   Chrysler:
     categories:
       - automotive
@@ -587,6 +700,12 @@ terms:
   Citroën:
     categories:
       - automotive
+  ClamAV:
+    categories:
+      - antivirus
+  Claude:
+    categories:
+      - LLM
   CLI:
     expanded_form: Command Line Interface
     plural: CLIs
@@ -602,6 +721,9 @@ terms:
   CloudFront:
     categories:
       - cloud
+  CloudWatch:
+    categories:
+      - monitoring
   CMake:
     categories:
       - build tool
@@ -612,6 +734,12 @@ terms:
   CockroachDB:
     categories:
       - database
+  Codacy:
+    categories:
+      - code quality
+  CodeIgniter:
+    categories:
+      - web framework
   CodePen:
     categories:
       - software
@@ -631,9 +759,24 @@ terms:
   CommonMark:
     categories:
       - markup language
+  Composer:
+    categories:
+      - package management
+      - PHP
+      - software
   Confluence:
     categories:
       - software
+      - Atlassian
+  Conventional Commits:
+    categories:
+      - versioning
+      - standard
+  Copilot:
+    disambiguation:
+      - copilot (car)
+    categories:
+      - LLM
   CoreDNS:
     categories:
       - dns
@@ -656,6 +799,10 @@ terms:
     plural: CPUs
     categories:
       - hardware
+  CQRS:
+    expanded_form: Command Query Responsibility Segregation
+    categories:
+      - architecture
   CRM:
     expanded_form: Customer Relationship Management
     categories:
@@ -668,6 +815,13 @@ terms:
     categories:
       - language
       - Croatia
+  Cron:
+    categories:
+      - scheduling
+  Cronjob:
+    plural: Cronjobs
+    categories:
+      - scheduling
   CRUD:
     expanded_form: Create, Read, Update, Delete
     categories:
@@ -686,6 +840,10 @@ terms:
       - software
       - linter
       - spell checker
+  CSR:
+    expanded_form: Client Side Rendering
+    categories:
+      - architecture
   CSS:
     expanded_form: Cascading Style Sheets
     categories:
@@ -698,6 +856,10 @@ terms:
     expanded_form: Comma-Separated Values
     categories:
       - data format
+  CUPS:
+    expanded_form: Common Unix Printing System
+    categories:
+      - printing
   cURL:
     expanded_form: Client for URL
     categories:
@@ -724,6 +886,9 @@ terms:
   D:
     categories:
       - programming language
+  D3:
+    categories:
+      - visualization
   DAB+:
     expanded_form: Digital Audio Broadcasting Plus
     categories:
@@ -754,9 +919,15 @@ terms:
       - software
       - password manager
       - security
+  DataDog:
+    categories:
+      - monitoring
   DataGrip:
     categories:
       - software
+  DataRobot:
+    categories:
+      - machine learning
   DB2:
     categories:
       - database
@@ -891,12 +1062,19 @@ terms:
     expanded_form: Denial of Service
     categories:
       - security
+  DotNet:
+    categories:
+      - framework
   DRP:
     expanded_form: Disaster Recovery Planning
     categories:
       - business
       - document
       - emergency management
+  Drupal:
+    categories:
+      - CMS
+      - PHP
   DRY:
     expanded_form: Don't Repeat Yourself
     disambiguation:
@@ -968,21 +1146,41 @@ terms:
       - language
       - demonym
       - nationality
+  Elastic Stack:
+    categories:
+      - monitoring
   Elasticsearch:
     categories:
       - search
       - analytics
       - database
+  Electron:
+    disambiguation:
+      - electron (the particle)
+    categories:
+      - framework
   Elixir:
     disambiguation:
       - Elixir (the programming language)
       - elixir (the potion)
     categories:
       - programming language
+  ELT:
+    expanded_form: Extract, Load, Transform
+    categories:
+      - data processing
+  EMA:
+    expanded_form: European Medicines Agency
+    categories:
+      - government agency
+      - Europe
   Emacs:
     categories:
       - software
       - text editor
+  Ember.js:
+    categories:
+      - web framework
   EMEA:
     expanded_form: Europe, Middle East and Africa
     categories:
@@ -990,6 +1188,9 @@ terms:
   English:
     categories:
       - language
+  Envato:
+    categories:
+      - company
   EOF:
     expanded_form: End Of File
     categories:
@@ -998,6 +1199,11 @@ terms:
     expanded_form: End Of Line
     categories:
       - programming
+  EPSON:
+    expanded_form: Electronic Printer's Son
+    categories:
+      - hardware
+      - printing
   EPUB:
     expanded_form: Electronic Publication
     categories:
@@ -1040,6 +1246,16 @@ terms:
     expanded_form: Entity Tag
     categories:
       - web development
+  Ethereum:
+    categories:
+      - blockchain
+  ETL:
+    expanded_form: Extract, Transform, Load
+    categories:
+      - data processing
+  Etsy:
+    categories:
+      - company
   EU:
     expanded_form: European Union
     categories:
@@ -1051,6 +1267,11 @@ terms:
       - continent
       - region
       - organization
+  European:
+    plural: Europeans
+    categories:
+      - demonym
+      - Europe
   Excel:
     categories:
       - software
@@ -1058,6 +1279,13 @@ terms:
     expanded_form: Extended File Allocation Table
     categories:
       - file system
+  EXIF:
+    expanded_form: Exchangeable Image File Format
+    categories:
+      - data format
+  Express.js:
+    categories:
+      - web framework
   ext2:
     categories:
       - file system
@@ -1108,6 +1336,16 @@ terms:
     expanded_form: File Allocation Table 32
     categories:
       - file system
+  FBI:
+    expanded_form: Federal Bureau of Investigation
+    categories:
+      - government agency
+      - USA
+  FDA:
+    expanded_form: Food and Drug Administration
+    categories:
+      - government agency
+      - USA
   Ferrari:
     categories:
       - automotive
@@ -1121,10 +1359,27 @@ terms:
       - sports
       - international
       - organization
+  FIFA:
+    expanded_form: Fédération Internationale de Football Association
+    categories:
+      - sports
+      - international
+      - organization
+  FIFO:
+    expanded_form: First in, First out
+    categories:
+      - caching
+  Figma:
+    categories:
+      - design
   FileZilla:
     categories:
       - software
       - file transfer
+  FILO:
+    expanded_form: First in, Last out
+    categories:
+      - caching
   Finland:
     categories:
       - country
@@ -1147,6 +1402,9 @@ terms:
   Firestore:
     categories:
       - database
+  Flask:
+    categories:
+      - web framework
   Flickr:
     categories:
       - photo
@@ -1216,6 +1474,10 @@ terms:
     expanded_form: File Transfer Protocol
     categories:
       - protocol
+  GAFAM:
+    expanded_form: Google, Apple, Facebook, Amazon, Microsoft
+    categories:
+      - company
   GB:
     expanded_form: Great Britain
     categories:
@@ -1232,10 +1494,28 @@ terms:
   GeForce:
     categories:
       - hardware
+  Gemfile:
+    categories:
+      - configuration
+  Gemini:
+    categories:
+      - LLM
   GenAI:
     expanded_form: Generative Artificial Intelligence
     categories:
       - artificial intelligence
+  Geneva:
+    categories:
+      - city
+      - capital
+      - Switzerland
+  Geneva Conventions:
+    categories:
+      - agreement
+      - treaty
+      - military
+      - international
+      - law
   GeoJSON:
     categories:
       - data format
@@ -1294,6 +1574,25 @@ terms:
   GitHub Actions:
     categories:
       - continuous integration
+  GitHub API:
+    categories:
+      - API
+      - GitHub
+  GitHub CLI Tool:
+    categories:
+      - CLI
+      - GitHub
+  GitHub Labels:
+    categories:
+      - GitHub
+  GitHub Pages:
+    categories:
+      - hosting
+      - GitHub
+  GitHub Webhooks:
+    categories:
+      - API
+      - GitHub
   GitLab:
     categories:
       - software
@@ -1302,6 +1601,14 @@ terms:
     categories:
       - continuous integration
       - GitLab
+  GitLab Pages:
+    categories:
+      - hosting
+      - GitLab
+  gitmoji:
+    categories:
+      - emoji
+      - Git
   GlassFish:
     categories:
       - web server
@@ -1317,6 +1624,12 @@ terms:
     expanded_form: Greenwich Mean Time
     categories:
       - timezone
+  GNOME:
+    expanded_form: GNU Network Object Model Environment
+    disambiguation:
+      - gnome (the mythical creature)
+    categories:
+      - desktop environment
   GNU:
     expanded_form: GNU's Not Unix
     categories:
@@ -1340,6 +1653,16 @@ terms:
   Google:
     categories:
       - company
+      - GAFAM
+      - Alphabet
+  Google Ads:
+    categories:
+      - advertising
+      - Google
+  Google Chrome:
+    categories:
+      - browser
+      - Google
   Google Cloud Functions:
     categories:
       - cloud
@@ -1351,6 +1674,20 @@ terms:
   Google Drive:
     categories:
       - cloud
+      - Google
+  Google Fiber:
+    categories:
+      - internet service
+      - Google
+  Google Maps:
+    categories:
+      - mapping
+      - Google
+  Google Play:
+    categories:
+      - store
+      - Google
+      - Android
   Google Suite:
     categories:
       - software
@@ -1414,6 +1751,10 @@ terms:
     expanded_form: Google Remote Procedure Call
     categories:
       - api
+  GRUB:
+    expanded_form: Grand Unified Bootloader
+    categories:
+      - bootloader
   GSM:
     expanded_form: Global System for Mobile Communications
     categories:
@@ -1485,6 +1826,10 @@ terms:
     expanded_form: Hierarchical File System Plus
     categories:
       - file system
+  Hibernate:
+    categories:
+      - ORM
+      - Java
   Hindi:
     categories:
       - language
@@ -1573,6 +1918,10 @@ terms:
     expanded_form: Infrastructure as a Service
     categories:
       - cloud
+  IaC:
+    expanded_form: Infrastructure as Code
+    categories:
+      - architecture
   IANA:
     expanded_form: Internet Assigned Numbers Authority
     categories:
@@ -1603,6 +1952,21 @@ terms:
     plural: IDEs
     categories:
       - software
+  IE:
+    expanded_form: Internet Explorer
+    disambiguation:
+      - IE (Latin abbreviation for id est)
+      - IE (country code for ireland)
+    categories:
+      - web browser
+  IE6:
+    expanded_form: Internet Explorer 6
+    categories:
+      - web browser
+  IE7:
+    expanded_form: Internet Explorer 7
+    categories:
+      - web browser
   IEA:
     expanded_form: International Energy Agency
     categories:
@@ -1685,6 +2049,9 @@ terms:
   InterBase:
     categories:
       - database
+  Internet Explorer:
+    categories:
+      - web browser
   IoC:
     expanded_form: Inversion of Control
     categories:
@@ -1890,6 +2257,10 @@ terms:
     categories:
       - country
       - Asia
+  KDE:
+    expanded_form: K Desktop Environment
+    categories:
+      - desktop environment
   KeePass:
     categories:
       - software
@@ -1963,6 +2334,9 @@ terms:
   Latin:
     categories:
       - language
+  Latin-1:
+    categories:
+      - character encoding
   Latvia:
     categories:
       - country
@@ -2010,6 +2384,10 @@ terms:
   LibreOffice:
     categories:
       - software
+  LIFO:
+    expanded_form: Last in, First out
+    categories:
+      - caching
   Lincoln:
     categories:
       - automotive
@@ -2061,6 +2439,9 @@ terms:
       - operating system
       - Linux distribution
       - Ubuntu variant
+  LXQt:
+    categories:
+      - desktop environment
   MacBook:
     categories:
       - hardware
@@ -2075,10 +2456,18 @@ terms:
   macOS:
     categories:
       - operating system
+      - Apple
+  Magento:
+    categories:
+      - ecommerce
   MailChimp:
     categories:
       - email
       - marketing
+  Mailgun:
+    categories:
+      - communication
+      - email
   Makefile:
     categories:
       - build tool
@@ -2145,6 +2534,9 @@ terms:
   Microsoft SQL Server:
     categories:
       - database
+  Microsoft Teams:
+    categories:
+      - communication
   Microsoft Windows:
     categories:
       - operating system
@@ -2194,6 +2586,10 @@ terms:
     categories:
       - language
       - Mongolia
+  MooTools:
+    categories:
+      - web framework
+      - JavaScript
   Moroccan:
     categories:
       - language
@@ -2254,6 +2650,10 @@ terms:
     expanded_form: Minimum Viable Product
     categories:
       - product development
+  MVVM:
+    expanded_form: Model-View-ViewModel
+    categories:
+      - architecture
   MyRocks:
     categories:
       - database
@@ -2323,6 +2723,12 @@ terms:
   Netlify:
     categories:
       - hosting
+  New Relic:
+    categories:
+      - monitoring
+  Next.js:
+    categories:
+      - web framework
   Nextcloud:
     categories:
       - cloud
@@ -2360,6 +2766,9 @@ terms:
   NixOS:
     categories:
       - operating system
+  Node.js:
+    categories:
+      - runtime
   Nominatim:
     categories:
       - mapping
@@ -2391,6 +2800,9 @@ terms:
     expanded_form: New Technology File System
     categories:
       - file system
+  NuGet:
+    categories:
+      - package management
   Nvidia:
     categories:
       - hardware
@@ -2601,6 +3013,9 @@ terms:
   Pagani:
     categories:
       - automotive
+  PagerDuty:
+    categories:
+      - monitoring
   Pakistan:
     categories:
       - country
@@ -2609,6 +3024,11 @@ terms:
     categories:
       - database
   Parcel:
+  Paris:
+    categories:
+      - city
+      - capital
+      - France
   PascalCase:
     categories:
       - programming style
@@ -2770,6 +3190,9 @@ terms:
     categories:
       - monitoring
       - observability
+  proselint:
+    categories:
+      - linting
   PubSub:
     expanded_form: Publish-Subscribe
     categories:
@@ -2875,10 +3298,25 @@ terms:
   Renault:
     categories:
       - automotive
+  Renovate:
+    categories:
+      - dependency management
+    disambiguation:
+      - renovate (the verb)
   RequireJS:
     categories:
       - JavaScript
       - module loader
+  REST:
+    expanded_form: Representational State Transfer
+    disambiguation:
+      - rest (the opposite of work)
+    categories:
+      - architectural style
+  REST API:
+    plural: REST APIs
+    categories:
+      - web service
   RESTful:
     categories:
       - architectural style
@@ -2932,6 +3370,14 @@ terms:
     expanded_form: Remote Procedure Call
     categories:
       - network
+  RPM:
+    expanded_form: Red Hat Package Manager
+    categories:
+      - package management
+  RPMS:
+    expanded_form: Red Hat Package Manager Specification
+    categories:
+      - package management
   RSA:
     expanded_form: Rivest–Shamir–Adleman
     categories:
@@ -2940,6 +3386,11 @@ terms:
     expanded_form: Really Simple Syndication
     categories:
       - communication
+  RTFM:
+    expanded_form: Read The Fucking Manual
+    categories:
+      - humor
+      - slang
   Ruby:
     disambiguation:
       - ruby (the gemstone)
@@ -3006,6 +3457,9 @@ terms:
   Scala:
     categories:
       - programming language
+  Schengen:
+    categories:
+      - city
   Schengen Area:
     categories:
       - agreement
@@ -3065,6 +3519,13 @@ terms:
     categories:
       - versioning
       - standard
+  SendGrid:
+    categories:
+      - communication
+      - email
+  Sentry:
+    categories:
+      - monitoring
   SEO:
     expanded_form: Search Engine Optimization
     categories:
@@ -3192,6 +3653,13 @@ terms:
     categories:
       - country
       - Asia
+  SPA:
+    expanded_form: Single Page Application
+    categories:
+      - architecture
+  SpaceX:
+    categories:
+      - aerospace
   Spanish:
     categories:
       - language
@@ -3199,6 +3667,9 @@ terms:
   SphinxDoc:
     categories:
       - documentation
+  Splunk:
+    categories:
+      - monitoring
   Spotify:
     categories:
       - audio
@@ -3250,6 +3721,10 @@ terms:
     categories:
       - security
       - identity
+  SSR:
+    expanded_form: Server Side Rendering
+    categories:
+      - architecture
   Stack Exchange:
     categories:
       - community
@@ -3265,12 +3740,23 @@ terms:
     categories:
       - automotive
       - group
+  Stripe:
+    disambiguation:
+      - stripe (the alternated bands)
+    categories:
+      - payment
+      - financial
   Subaru:
     categories:
       - automotive
   Sublime Text:
     categories:
       - text editor
+  Subversion:
+    categories:
+      - version control
+    disambiguation:
+      - subversion (the concept)
   SunOS:
     categories:
       - operating system
@@ -3284,6 +3770,11 @@ terms:
   Suzuki:
     categories:
       - automotive
+  Svelte:
+    disambiguation:
+      - svelte (the adjective meaning thin)
+    categories:
+      - framework
   SVG:
     expanded_form: Scalable Vector Graphics
     categories:
@@ -3317,10 +3808,19 @@ terms:
   Swift:
     categories:
       - programming language
+  Swiss:
+    categories:
+      - nationality
+      - Switzerland
   Swiss Army:
     categories:
       - military
       - organization
+  Swiss Army knife:
+    plural: Swiss Army knives
+    categories:
+      - tool
+      - utility
   Switzerland:
     categories:
       - country
@@ -3406,6 +3906,11 @@ terms:
     categories:
       - social media
       - video
+  TLD:
+    expanded_form: Top-Level Domain
+    plural: TLDs
+    categories:
+      - domain
   TLS:
     expanded_form: Transport Layer Security
     categories:
@@ -3419,6 +3924,18 @@ terms:
     categories:
       - configuration
       - markup language
+  TortoiseGit:
+    categories:
+      - version control
+      - Git
+  TortoiseHG:
+    categories:
+      - version control
+      - Mercurial
+  TortoiseSVN:
+    categories:
+      - version control
+      - Subversion
   TOTP:
     expanded_form: Time-based One-Time Password
     categories:
@@ -3477,6 +3994,13 @@ terms:
     expanded_form: Television Operating System
     categories:
       - operating system
+  Twilio:
+    categories:
+      - communication
+  Twitch:
+    categories:
+      - streaming
+      - video
   Twitter:
     categories:
       - social media
@@ -3516,7 +4040,11 @@ terms:
   UDP:
     expanded_form: User Datagram Protocol
     categories:
-      - networking
+      - network
+  UEFA:
+    expanded_form: Union of European Football Associations
+    categories:
+      - sports
   UEFI:
     expanded_form: Unified Extensible Firmware Interface
     categories:
@@ -3834,6 +4362,9 @@ terms:
   Wikitext:
     categories:
       - markup language
+  Wiktionary:
+    categories:
+      - dictionary
   Windows:
     categories:
       - operating system
@@ -3859,6 +4390,18 @@ terms:
     expanded_form: World Wide Fund for Nature
     categories:
       - organization
+  WWW:
+    expanded_form: World Wide Web
+    categories:
+      - internet
+  WYSIWYG:
+    expanded_form: What You See Is What You Get
+    categories:
+      - web development
+  WYSIWYM:
+    expanded_form: What You See Is What You Mean
+    categories:
+      - web development
   X:
     categories:
       - social network
@@ -3870,6 +4413,12 @@ terms:
     expanded_form: Cross-Platform, Apache, MySQL, PHP, Perl
     categories:
       - software stack
+  Xbox:
+    categories:
+      - gaming
+  Xbox 360:
+    categories:
+      - gaming
   Xcode:
     categories:
       - IDE
@@ -3882,6 +4431,10 @@ terms:
     expanded_form: X Desktop Group
     categories:
       - standard
+  Xerok:
+    categories:
+      - hardware
+      - printing
   XFCE:
     expanded_form: XForms Common Environment
     categories:

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -5,6 +5,13 @@ terms:
     expanded_form: Triple Data Encryption Standard
     categories:
       - cryptography
+  ACID:
+    expanded_form: Atomicity, Consistency, Isolation, Durability
+    disambiguation:
+      - acid (chemical)
+    categories:
+      - database
+      - data storage
   ACL:
     expanded_form: Access Control List
     plural: ACLs
@@ -76,6 +83,9 @@ terms:
   Amazon:
     categories:
       - company
+  Amazon DynamoDB:
+    categories:
+      - database
   AMQP:
     expanded_form: Advanced Message Queuing Protocol
     categories:
@@ -101,6 +111,15 @@ terms:
       - Apache (the Native American tribe)
     categories:
       - software
+  Apache Cassandra:
+    categories:
+      - database
+  Apache CouchDB:
+    categories:
+      - database
+  Apache OpenNLP:
+    categories:
+      - natural language processing
   API:
     expanded_form: Application Programming Interface
     plural: APIs
@@ -159,6 +178,11 @@ terms:
   Audi:
     categories:
       - automotive
+  Aurora:
+    disambiguation:
+      - aurora (Northern light)
+    categories:
+      - database
   Australia:
     categories:
       - country
@@ -210,6 +234,12 @@ terms:
   BeOS:
     categories:
       - operating system
+  Berkeley DB:
+    categories:
+      - database
+  BigQuery:
+    categories:
+      - database
   Bitbucket:
     categories:
       - software
@@ -335,6 +365,9 @@ terms:
       - demonym
       - language
       - Canada
+  Caspio:
+    categories:
+      - database
   Cassandra:
     categories:
       - database
@@ -566,11 +599,21 @@ terms:
       - dart (the game)
     categories:
       - programming language
+  DB2:
+    categories:
+      - database
   DBA:
     expanded_form: Database Administrator
     plural: DBAs
     categories:
       - job role
+      - database
+  dBASE:
+    categories:
+      - database
+  DBMS:
+    expanded_form: Database Management System
+    categories:
       - database
   DBus:
     expanded_form: Desktop Bus
@@ -855,9 +898,15 @@ terms:
   Firebase:
     categories:
       - cloud
+  Firebird:
+    categories:
+      - database
   Firefox:
     categories:
       - browser
+  Firestore:
+    categories:
+      - database
   Flickr:
     categories:
       - photo
@@ -1298,6 +1347,12 @@ terms:
     expanded_form: Influx Database
     categories:
       - database
+  Informix:
+    categories:
+      - database
+  Ingres:
+    categories:
+      - database
   Insomnia:
     disambiguation:
       - insomnia (the sleep disorder)
@@ -1311,7 +1366,10 @@ terms:
       - hardware
   IntelliJ:
     categories:
-      - ide
+      - IDE
+  InterBase:
+    categories:
+      - database
   IoC:
     expanded_form: Inversion of Control
     categories:
@@ -1725,6 +1783,9 @@ terms:
   Microsoft:
     categories:
       - company
+  Microsoft SQL Server:
+    categories:
+      - database
   Microsoft Windows:
     categories:
       - operating system
@@ -1819,6 +1880,9 @@ terms:
     expanded_form: Message Queuing Telemetry Transport
     categories:
       - messaging
+  MS Access:
+    categories:
+      - database
   MVC:
     expanded_form: Model-View-Controller
     categories:
@@ -1959,6 +2023,14 @@ terms:
     expanded_form: Optical Character Recognition
     categories:
       - computer vision
+  ODBC:
+    expanded_form: Open Database Connectivity
+    categories:
+      - database
+  ODM:
+    expanded_form: Object Document Mapper
+    categories:
+      - database
   OIDC:
     expanded_form: OpenID Connect
     categories:
@@ -2125,6 +2197,9 @@ terms:
     categories:
       - country
       - Asia
+  Paradox:
+    categories:
+      - database
   Parcel:
   PascalCase:
     categories:
@@ -2326,6 +2401,10 @@ terms:
     expanded_form: Random Access Memory
     categories:
       - hardware
+  RDS:
+    expanded_form: Amazon Relational Database Service
+    categories:
+      - database
   React:
     disambiguation:
       - react (the verb)
@@ -2763,6 +2842,10 @@ terms:
     categories:
       - country
       - Europe
+  Sybase:
+    categories:
+      - database
+      - SQL
   Symfony:
     categories:
       - software

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -440,6 +440,17 @@ terms:
     categories:
       - operating system
       - Linux distribution
+  CERN:
+    expanded_form: European Organization for Nuclear Research
+    categories:
+      - international
+      - organization
+      - energy
+      - research
+      - particle physics
+      - nuclear
+      - science
+      - Europe
   CERT:
     expanded_form: Computer Emergency Response Team
     categories:
@@ -916,6 +927,12 @@ terms:
     expanded_form: Entity Tag
     categories:
       - web development
+  EU:
+    expanded_form: European Union
+    categories:
+      - international
+      - organization
+      - Europe
   Europe:
     categories:
       - continent
@@ -960,6 +977,12 @@ terms:
     expanded_form: Fabbrica Italiana Automobili Torino
     categories:
       - automotive
+  FIBA:
+    expanded_form: Fédération Internationale de Basketball
+    categories:
+      - sports
+      - international
+      - organization
   FileZilla:
     categories:
       - software
@@ -1105,6 +1128,12 @@ terms:
     expanded_form: Gigahertz
     categories:
       - hardware
+  GIEC:
+    expanded_form: Groupe d'experts intergouvernemental sur l'évolution du climat
+    categories:
+      - international
+      - organization
+      - climate
   GIF:
     expanded_form: Graphics Interchange Format
     categories:
@@ -1400,6 +1429,17 @@ terms:
     plural: IDEs
     categories:
       - software
+  IEA:
+    expanded_form: International Energy Agency
+    categories:
+      - international
+      - organization
+      - energy
+  IEEE:
+    expanded_form: Institute of Electrical and Electronics Engineers
+    categories:
+      - standard
+      - organization
   IETF:
     expanded_form: Internet Engineering Task Force
     categories:
@@ -1419,6 +1459,12 @@ terms:
     expanded_form: Internet Message Access Protocol version 4
     categories:
       - protocol
+  IMF:
+    expanded_form: International Monetary Fund
+    categories:
+      - international
+      - organization
+      - financial
   IndexedDB:
     expanded_form: Indexed Database API
     categories:
@@ -2018,6 +2064,20 @@ terms:
     expanded_form: Not a Number
     categories:
       - programming
+  NASA:
+    expanded_form: National Aeronautics and Space Administration
+    categories:
+      - organization
+      - aerospace
+  NATO:
+    expanded_form: North Atlantic Treaty Organization
+    categories:
+      - international
+      - organization
+      - treaty
+      - military
+      - North America
+      - Europe
   NATS:
     expanded_form: Not Another Topic System
     categories:
@@ -3003,6 +3063,10 @@ terms:
   Swift:
     categories:
       - programming language
+  Swiss Army:
+    categories:
+      - military
+      - organization
   Switzerland:
     categories:
       - country
@@ -3190,6 +3254,11 @@ terms:
       - operating system
       - Linux distribution
       - Ubuntu variant
+  UCI:
+    expanded_form: Union Cycliste Internationale
+    categories:
+      - sports
+      - organization
   UDP:
     expanded_form: User Datagram Protocol
     categories:
@@ -3219,6 +3288,19 @@ terms:
     expanded_form: Unified Modeling Language
     categories:
       - modeling
+  UNESCO:
+    expanded_form: United Nations Educational, Scientific and Cultural Organization
+    categories:
+      - international
+      - organization
+      - cultural
+      - science
+  UNICEF:
+    expanded_form: United Nations International Children's Emergency Fund
+    categories:
+      - international
+      - organization
+      - humanitarian
   Unicode:
     categories:
       - encoding
@@ -3457,10 +3539,23 @@ terms:
     categories:
       - language
       - Wales
+  WFP:
+    expanded_form: World Food Programme
+    categories:
+      - international
+      - organization
+      - humanitarian
   WhatsApp:
     categories:
       - communication
       - software
+      - Meta Platforms, Inc.
+  WHO:
+    expanded_form: World Health Organization
+    categories:
+      - international
+      - organization
+      - health
   Wi-Fi:
     expanded_form: Wireless Fidelity
     categories:
@@ -3498,6 +3593,10 @@ terms:
     categories:
       - conference
       - web
+  WWF:
+    expanded_form: World Wide Fund for Nature
+    categories:
+      - organization
   X:
     categories:
       - social network

--- a/jargon.yaml
+++ b/jargon.yaml
@@ -1,6 +1,11 @@
 ---
 # yaml-language-server: $schema=./jsonschema/jargon.v0.schema.json
 terms:
+  1Password:
+    categories:
+      - software
+      - password manager
+      - security
   3DES:
     expanded_form: Triple Data Encryption Standard
     categories:
@@ -26,6 +31,14 @@ terms:
   Adobe:
     categories:
       - company
+  Adobe Acrobat:
+    categories:
+      - software
+      - pdf
+  Adobe Acrobat Reader:
+    categories:
+      - software
+      - pdf
   ADSL:
     expanded_form: Asymmetric Digital Subscriber Line
     categories:
@@ -40,6 +53,11 @@ terms:
     categories:
       - continent
       - region
+  Agile:
+    disambiguation:
+      - agile (the adjective)
+    categories:
+      - software development
   AGPL:
     expanded_form: Affero General Public License
     categories:
@@ -77,8 +95,13 @@ terms:
     categories:
       - operating system
       - Linux distribution
-  Altassian:
+  ALSA:
+    expanded_form: Advanced Linux Sound Architecture
+    disambiguation:
+      - ALSA (the American Life Science Association)
+      - ALSA (Automóviles Luarca, S.A., a bus company in Europe)
     categories:
+      - audio
       - software
   Amazon:
     categories:
@@ -155,6 +178,9 @@ terms:
     categories:
       - language
       - Armenia
+  Asana:
+    categories:
+      - software
   ASCII:
     expanded_form: American Standard Code for Information Interchange
     categories:
@@ -172,6 +198,11 @@ terms:
   Aston Martin:
     categories:
       - automotive
+  ATDD:
+    expanded_form: Acceptance Test-Driven Development
+    categories:
+      - software development
+      - testing
   Atlassian:
     categories:
       - company
@@ -186,6 +217,9 @@ terms:
   Australia:
     categories:
       - country
+  AutoCAD:
+    categories:
+      - software
   AWS:
     expanded_form: Amazon Web Services
     categories:
@@ -216,6 +250,10 @@ terms:
     categories:
       - shell
       - programming language
+  BDD:
+    expanded_form: Behavior-Driven Development
+    categories:
+      - software development
   Belarus:
     categories:
       - country
@@ -249,6 +287,11 @@ terms:
   BitTorrent:
     categories:
       - protocol
+  Bitwarden:
+    categories:
+      - software
+      - password manager
+      - security
   Blu-ray:
     categories:
       - hardware
@@ -324,6 +367,10 @@ terms:
   Bugatti:
     categories:
       - automotive
+  Bugzilla:
+    categories:
+      - software
+      - bug tracking
   Bulgaria:
     categories:
       - country
@@ -437,6 +484,9 @@ terms:
   CircleCI:
     categories:
       - continuous integration
+  Citrix:
+    categories:
+      - software
   Citroën:
     categories:
       - automotive
@@ -465,6 +515,9 @@ terms:
   CockroachDB:
     categories:
       - database
+  CodePen:
+    categories:
+      - software
   CodeQL:
     categories:
       - security
@@ -599,6 +652,14 @@ terms:
       - dart (the game)
     categories:
       - programming language
+  Dashlane:
+    categories:
+      - software
+      - password manager
+      - security
+  DataGrip:
+    categories:
+      - software
   DB2:
     categories:
       - database
@@ -619,6 +680,10 @@ terms:
     expanded_form: Desktop Bus
     categories:
       - software
+  DDD:
+    expanded_form: Domain-Driven Design
+    categories:
+      - software development
   DDL:
     expanded_form: Data Definition Language
     plural: DDLs
@@ -716,6 +781,12 @@ terms:
   DOS:
     categories:
       - operating system
+  DRY:
+    expanded_form: Don't Repeat Yourself
+    disambiguation:
+      - dry (the opposite of wet)
+    categories:
+      - software design principles
   DS Automobiles:
     categories:
       - automotive
@@ -788,6 +859,10 @@ terms:
       - elixir (the potion)
     categories:
       - programming language
+  Emacs:
+    categories:
+      - software
+      - text editor
   EMEA:
     expanded_form: Europe, Middle East and Africa
     categories:
@@ -885,6 +960,10 @@ terms:
     expanded_form: Fabbrica Italiana Automobili Torino
     categories:
       - automotive
+  FileZilla:
+    categories:
+      - software
+      - file transfer
   Finland:
     categories:
       - country
@@ -1030,6 +1109,10 @@ terms:
     expanded_form: Graphics Interchange Format
     categories:
       - image format
+  GIMP:
+    expanded_form: GNU Image Manipulation Program
+    categories:
+      - software
   Git:
     categories:
       - version control
@@ -1085,9 +1168,12 @@ terms:
   Google:
     categories:
       - company
-  GoogleCloud:
+  Google Suite:
     categories:
-      - cloud
+      - software
+      - productivity
+      - collaboration
+      - Google
   GopherCon:
     categories:
       - conference
@@ -1114,6 +1200,10 @@ terms:
   Grafana:
     categories:
       - monitoring
+  Grammarly:
+    categories:
+      - software
+      - grammar checker
   GraphAPI:
     categories:
       - api
@@ -1260,6 +1350,11 @@ terms:
     categories:
       - country
       - Europe
+  Husky:
+    disambiguation:
+      - husky (the dog breed)
+    categories:
+      - software
   Hyundai:
     categories:
       - automotive
@@ -1559,6 +1654,13 @@ terms:
   Kibana:
     categories:
       - monitoring
+  KISS:
+    expanded_form: Keep It Simple, Stupid
+    disambiguation:
+      - Kiss (the band)
+      - kiss (the greeting)
+    categories:
+      - software principle
   Kiswahili:
     categories:
       - language
@@ -1584,6 +1686,10 @@ terms:
   Lamborghini:
     categories:
       - automotive
+  LAMP:
+    expanded_form: Linux, Apache, MySQL, PHP
+    categories:
+      - software stack
   LAN:
     expanded_form: Local Area Network
     categories:
@@ -1623,6 +1729,10 @@ terms:
   Launchpad:
     categories:
       - software
+  Lazygit:
+    categories:
+      - software
+      - Git
   LDAP:
     expanded_form: Lightweight Directory Access Protocol
     categories:
@@ -1783,6 +1893,10 @@ terms:
   Microsoft:
     categories:
       - company
+      - GAFAM
+  Microsoft 365:
+    categories:
+      - software
   Microsoft SQL Server:
     categories:
       - database
@@ -1956,6 +2070,10 @@ terms:
   nginx:
     categories:
       - web server
+  NIH:
+    expanded_form: Not Invented Here
+    categories:
+      - software development
   Nissan:
     categories:
       - automotive
@@ -1984,6 +2102,13 @@ terms:
   NoSQL:
     categories:
       - database
+  Notepad++:
+    categories:
+      - software
+      - text editor
+  Notion:
+    categories:
+      - software
   npm:
     categories:
       - package management
@@ -2270,6 +2395,10 @@ terms:
     categories:
       - social media
       - image sharing
+  PipeWire:
+    categories:
+      - audio
+      - software
   PIPL:
     expanded_form: Personal Information Protection Law
     categories:
@@ -2290,6 +2419,10 @@ terms:
     categories:
       - package manager
       - JavaScript
+  PoC:
+    expanded_form: Proof of Concept
+    categories:
+      - software development
   Poland:
     categories:
       - country
@@ -2328,9 +2461,16 @@ terms:
   PostScript:
     categories:
       - markup language
+  PowerPoint:
+    categories:
+      - presentation software
   PowerShell:
     categories:
       - shell
+      - Microsoft Windows
+  PowerTools:
+    categories:
+      - software
       - Microsoft Windows
   Prettier:
     disambiguation:
@@ -2640,6 +2780,21 @@ terms:
     categories:
       - networking
       - file transfer
+  Shopify:
+    categories:
+      - software
+  Signal:
+    categories:
+      - communication
+  Silex:
+    disambiguation:
+      - silex (the rock)
+    categories:
+      - software
+  Sina Weibo:
+    categories:
+      - social network
+      - Asia
   SLA:
     plural: SLAs
     expanded_form: Service Level Agreement
@@ -2682,9 +2837,19 @@ terms:
     expanded_form: Simple Object Access Protocol
     categories:
       - web services
+  Socket.IO:
+    categories:
+      - software
+      - network
   Solaris:
     categories:
       - operating system
+  SOLID:
+    expanded_form: Single Responsibility, Open/Closed, Liskov Substitution, Interface Segregation, Dependency Inversion
+    categories:
+      - software design principles
+    disambiguation:
+      - solid (the state of matter)
   SolidJS:
     categories:
       - JavaScript
@@ -2854,6 +3019,9 @@ terms:
     categories:
       - language
       - Philippines
+  Tailwind:
+    categories:
+      - software
   Tamil:
     categories:
       - language
@@ -2873,7 +3041,24 @@ terms:
   TCP:
     expanded_form: Transmission Control Protocol
     categories:
-      - networking
+      - network
+  TDD:
+    expanded_form: Test-Driven Development
+    categories:
+      - software development
+  Telegram:
+    categories:
+      - social network
+      - messaging
+  Tencent:
+    categories:
+      - company
+      - software
+      - Asia
+  Tencent Weibo:
+    categories:
+      - social network
+      - Asia
   TensorFlow:
     categories:
       - machine learning
@@ -3165,6 +3350,11 @@ terms:
   Visual Studio Code:
     categories:
       - code editor
+  Vite:
+    disambiguation:
+      - vite (French word for speed)
+    categories:
+      - software
   VKontakte:
     categories:
       - social network
@@ -3322,6 +3512,11 @@ terms:
   Xcode:
     categories:
       - IDE
+  xDD:
+    expanded_form: eXtreme Test-Driven Development
+    categories:
+      - software development
+      - testing
   XDG:
     expanded_form: X Desktop Group
     categories:
@@ -3366,6 +3561,12 @@ terms:
       - operating system
       - Linux distribution
       - Ubuntu variant
+  YAGNI:
+    expanded_form: You Aren't Gonna Need It
+    categories:
+      - software design principles
+      - humor
+      - slang
   YAML:
     expanded_form: YAML Ain't Markup Language
     categories:


### PR DESCRIPTION
This PR is the result of months of work

The commits were split for clarity purpose,

No LLM or scrapping were involved. These are manual edits I made

All these changes comply with MIT license

- **feat: add categories to existing jargon terms**
- **feat: add operating system and Linux variants**
- **feat: add programming languages**
- **feat: add countries, languages, and other terms to jargon**
- **feat: add cars and moto manufacturers**
- **feat: add databases**
- **feat: add softwares and concepts**
- **feat: add organizations**
- **feat: add security and authentication terms**
- **feat: add cloud terms**
- **feat: add file systems and some file formats**
- **feat: add network terms**
- **feat: add R&D legal and contractual documents**
- **feat: add media**
- **feat: add miscellaneous jargon terms**
